### PR TITLE
Improve build system compatibility with PSAppDeployToolkit.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,11 +59,11 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="$(SolutionDir)BannedSymbols.txt" />
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\..\BannedSymbols.txt" />
   </ItemGroup>
 
   <!-- Common embedded resource for license -->
   <ItemGroup>
-    <EmbeddedResource Include="$(SolutionDir)LICENSE" />
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\..\LICENSE" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Because PSAppDeployToolkit consumes the project directory, we can't reference the SolutionDir like this.