### PR TITLE
Use null pattern matching instead of null equality checks.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Prefer `EventArgs.Empty`, `nameof(...)`, explicit `readonly`, and immutable help
 - **Target-typed `new()`**: `MainWindow mainWindow = new()` not `var mainWindow = new MainWindow()` — use when the type is clear from the declaration.
 - **Discard ignored returns with `_`**: methods that return a value must have the return consumed or explicitly discarded. `_ = Dispatcher.BeginInvoke(...)`, `_ = list.ApplyTemplate()`.
 - **`default` not `default(T)`**: `Assert.AreNotEqual(default, value)` not `Assert.AreNotEqual(default(Color), value)`.
-- **`is not` for null pattern checks**: `if (x is not FrameworkElement fe) throw ...` instead of `x as T; if (x == null) throw ...`.
+- **`is not` for null pattern checks**: `if (x is not FrameworkElement fe) throw ...` instead of `x as T; if (x is null) throw ...`.
 - **`??` throw expressions**: `FindVisualChildByName<T>(...) ?? throw new InvalidOperationException(...)` instead of a separate null-check + throw block.
 - **`const` for compile-time-known locals**: `const FrameworkPropertyMetadataOptions flags = ...` when a local's value is statically determined.
 - **Auto-properties over manual backing fields**: `public static Color SystemAccentColor { get; private set; }` instead of a `private static Color _systemAccentColor` field plus an expression-bodied getter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Prefer `EventArgs.Empty`, `nameof(...)`, explicit `readonly`, and immutable help
 - **Target-typed `new()`**: `MainWindow mainWindow = new()` not `var mainWindow = new MainWindow()` — use when the type is clear from the declaration.
 - **Discard ignored returns with `_`**: methods that return a value must have the return consumed or explicitly discarded. `_ = Dispatcher.BeginInvoke(...)`, `_ = list.ApplyTemplate()`.
 - **`default` not `default(T)`**: `Assert.AreNotEqual(default, value)` not `Assert.AreNotEqual(default(Color), value)`.
-- **`is not` for null pattern checks**: `if (x is not FrameworkElement fe) throw ...` instead of `x as T; if (x == null) throw ...`.
+- **`is not` for null pattern checks**: `if (x is not FrameworkElement fe) throw ...` instead of `x as T; if (x is null) throw ...`.
 - **`??` throw expressions**: `FindVisualChildByName<T>(...) ?? throw new InvalidOperationException(...)` instead of a separate null-check + throw block.
 - **`const` for compile-time-known locals**: `const FrameworkPropertyMetadataOptions flags = ...` when a local's value is statically determined.
 - **Auto-properties over manual backing fields**: `public static Color SystemAccentColor { get; private set; }` instead of a `private static Color _systemAccentColor` field plus an expression-bodied getter.

--- a/Fluence.Wpf.Demo.Mvvm/Converters/EnumToBoolConverter.cs
+++ b/Fluence.Wpf.Demo.Mvvm/Converters/EnumToBoolConverter.cs
@@ -44,7 +44,7 @@ namespace Fluence.Wpf.Demo.Mvvm.Converters
         /// <inheritdoc />
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value != null && value.Equals(parameter);
+            return value is not null && value.Equals(parameter);
         }
 
         /// <inheritdoc />

--- a/Fluence.Wpf.Demo/App.xaml.cs
+++ b/Fluence.Wpf.Demo/App.xaml.cs
@@ -139,7 +139,7 @@ namespace Fluence.Wpf.Demo
         private static T? FindVisualChildByName<T>(DependencyObject root, string name)
             where T : FrameworkElement
         {
-            if (root == null)
+            if (root is null)
             {
                 return null;
             }
@@ -153,7 +153,7 @@ namespace Fluence.Wpf.Demo
             for (int i = 0; i < childCount; i++)
             {
                 T? match = FindVisualChildByName<T>(VisualTreeHelper.GetChild(root, i), name);
-                if (match != null)
+                if (match is not null)
                 {
                     return match;
                 }
@@ -169,7 +169,7 @@ namespace Fluence.Wpf.Demo
 
         private static bool IsSmokeTest(string[] args)
         {
-            if (args == null)
+            if (args is null)
             {
                 return false;
             }

--- a/Fluence.Wpf.Demo/MainWindow.xaml.cs
+++ b/Fluence.Wpf.Demo/MainWindow.xaml.cs
@@ -78,8 +78,8 @@ namespace Fluence.Wpf.Demo
             _userShowTitle = ShowTitle;
             _userIcon = Icon;
             _userTitle = Title;
-            _userNavBackButtonVisible = DemoNav != null && DemoNav.IsBackButtonVisible;
-            _userNavPaneToggleButtonVisible = DemoNav == null || DemoNav.IsPaneToggleButtonVisible;
+            _userNavBackButtonVisible = DemoNav is not null && DemoNav.IsBackButtonVisible;
+            _userNavPaneToggleButtonVisible = DemoNav is null || DemoNav.IsPaneToggleButtonVisible;
 
             DemoNav?.SelectionChanged += DemoNav_SelectionChanged;
 
@@ -92,22 +92,22 @@ namespace Fluence.Wpf.Demo
         {
             _extendsDpd?.RemoveValueChanged(this, OnTitleBarDependencyChanged);
 
-            if (_paneModeDpd != null && DemoNav != null)
+            if (_paneModeDpd is not null && DemoNav is not null)
             {
                 _paneModeDpd.RemoveValueChanged(DemoNav, OnTitleBarDependencyChanged);
             }
 
-            if (_backEnabledDpd != null && DemoNav != null)
+            if (_backEnabledDpd is not null && DemoNav is not null)
             {
                 _backEnabledDpd.RemoveValueChanged(DemoNav, OnTitleBarDependencyChanged);
             }
 
-            if (_backVisibleDpd != null && DemoNav != null)
+            if (_backVisibleDpd is not null && DemoNav is not null)
             {
                 _backVisibleDpd.RemoveValueChanged(DemoNav, OnTitleBarDependencyChanged);
             }
 
-            if (_paneToggleVisibleDpd != null && DemoNav != null)
+            if (_paneToggleVisibleDpd is not null && DemoNav is not null)
             {
                 _paneToggleVisibleDpd.RemoveValueChanged(DemoNav, OnTitleBarDependencyChanged);
             }
@@ -119,7 +119,7 @@ namespace Fluence.Wpf.Demo
 
         private void PopulateNavigation()
         {
-            if (DemoNav == null)
+            if (DemoNav is null)
             {
                 return;
             }
@@ -140,7 +140,7 @@ namespace Fluence.Wpf.Demo
                 }
             }
 
-            if (defaultItem == null && DemoNav.Items.Count > 0)
+            if (defaultItem is null && DemoNav.Items.Count > 0)
             {
                 defaultItem = DemoNav.Items[0] as NavigationViewItem;
             }
@@ -166,7 +166,7 @@ namespace Fluence.Wpf.Demo
             }
 
             object? page = EnsurePageContent(selected);
-            if (page != null)
+            if (page is not null)
             {
                 DemoNav.Content = page;
                 AnimatePageInIfChanged(page);
@@ -179,12 +179,12 @@ namespace Fluence.Wpf.Demo
         /// <param name="tag">Search tag such as "buttons", "progress ring", or "window".</param>
         public void NavigateTo(string tag)
         {
-            if (DemoNav == null || string.IsNullOrWhiteSpace(tag))
+            if (DemoNav is null || string.IsNullOrWhiteSpace(tag))
             {
                 return;
             }
 
-            if (NavSearchBox != null && !string.IsNullOrWhiteSpace(NavSearchBox.Text))
+            if (NavSearchBox is not null && !string.IsNullOrWhiteSpace(NavSearchBox.Text))
             {
                 NavSearchBox.Text = string.Empty;
             }
@@ -194,7 +194,7 @@ namespace Fluence.Wpf.Demo
 
         private void NavigateToItem(NavigationViewItem? item)
         {
-            if (item == null || DemoNav == null)
+            if (item is null || DemoNav is null)
             {
                 return;
             }
@@ -212,7 +212,7 @@ namespace Fluence.Wpf.Demo
 
         private object? EnsurePageContent(NavigationViewItem item)
         {
-            if (item == null)
+            if (item is null)
             {
                 return null;
             }
@@ -284,7 +284,7 @@ namespace Fluence.Wpf.Demo
             }
 
             NavigationViewItem? match = FindFirstMatchingItem(query);
-            if (match != null)
+            if (match is not null)
             {
                 NavigateToItem(match);
                 e.Handled = true;
@@ -293,7 +293,7 @@ namespace Fluence.Wpf.Demo
 
         private NavigationViewItem? FindFirstMatchingItem(string query)
         {
-            if (DemoNav == null || string.IsNullOrWhiteSpace(query))
+            if (DemoNav is null || string.IsNullOrWhiteSpace(query))
             {
                 return null;
             }
@@ -309,7 +309,7 @@ namespace Fluence.Wpf.Demo
                 string title = (item.Content as string) ?? string.Empty;
                 _ = _navigationItemByContainer.TryGetValue(item, out DemoNavigationItem? metadata);
                 if (string.Equals(title, trimmed, StringComparison.OrdinalIgnoreCase) ||
-                    (metadata != null && string.Equals(metadata.Route, trimmed, StringComparison.OrdinalIgnoreCase)))
+                    (metadata is not null && string.Equals(metadata.Route, trimmed, StringComparison.OrdinalIgnoreCase)))
                 {
                     return item;
                 }
@@ -327,8 +327,8 @@ namespace Fluence.Wpf.Demo
         {
             string title = (item.Content as string) ?? string.Empty;
             string tag = (item.Tag as string) ?? string.Empty;
-            string route = metadata == null ? string.Empty : metadata.Route;
-            string keywords = metadata == null ? string.Empty : metadata.Keywords;
+            string route = metadata is null ? string.Empty : metadata.Route;
+            string keywords = metadata is null ? string.Empty : metadata.Keywords;
             return ContainsOrdinalIgnoreCase(title + " " + tag + " " + route + " " + keywords, needle);
         }
 
@@ -343,7 +343,7 @@ namespace Fluence.Wpf.Demo
 
         private void ApplyNavSearchFilter()
         {
-            if (DemoNav == null || NavSearchBox == null)
+            if (DemoNav is null || NavSearchBox is null)
             {
                 return;
             }
@@ -378,7 +378,7 @@ namespace Fluence.Wpf.Demo
 
         private void AnimatePageInIfChanged(object page)
         {
-            if (page == null || ReferenceEquals(_lastAnimatedPageContent, page))
+            if (page is null || ReferenceEquals(_lastAnimatedPageContent, page))
             {
                 return;
             }
@@ -455,7 +455,7 @@ namespace Fluence.Wpf.Demo
                 ExtendsContentIntoTitleBarProperty, typeof(FluenceWindow));
             _extendsDpd?.AddValueChanged(this, OnTitleBarDependencyChanged);
 
-            if (DemoNav != null)
+            if (DemoNav is not null)
             {
                 _paneModeDpd = DependencyPropertyDescriptor.FromProperty(
                     NavigationView.PaneDisplayModeProperty, typeof(NavigationView));
@@ -515,7 +515,7 @@ namespace Fluence.Wpf.Demo
 
             _ = (NavSearchBox?.Visibility = Visibility.Visible);
 
-            if (DemoNav != null)
+            if (DemoNav is not null)
             {
                 _isApplyingTitleBarChrome = true;
                 try
@@ -537,20 +537,20 @@ namespace Fluence.Wpf.Demo
                 }
             }
 
-            if (ShellTitleBar != null)
+            if (ShellTitleBar is not null)
             {
                 ShellTitleBar.Title = extendedTitleBar && _userShowTitle ? (_userTitle ?? string.Empty) : string.Empty;
-                if (extendedTitleBar && _userShowIcon && _userIcon != null)
+                if (extendedTitleBar && _userShowIcon && _userIcon is not null)
                 {
                     ShellTitleBar.Icon = GetTitleBarIconView();
                 }
                 ShellTitleBar.IsBackButtonVisible = extendedTitleBar
                     && _userNavBackButtonVisible
-                    && DemoNav != null
+                    && DemoNav is not null
                     && DemoNav.IsBackEnabled;
                 ShellTitleBar.IsPaneToggleButtonVisible = extendedTitleBar
                     && _userNavPaneToggleButtonVisible
-                    && DemoNav != null
+                    && DemoNav is not null
                     && DemoNav.PaneDisplayMode != NavigationViewPaneDisplayMode.Top;
             }
 
@@ -565,7 +565,7 @@ namespace Fluence.Wpf.Demo
 
         private Image GetTitleBarIconView()
         {
-            if (_titleBarIconView == null)
+            if (_titleBarIconView is null)
             {
                 _titleBarIconView = new Image
                 {
@@ -587,7 +587,7 @@ namespace Fluence.Wpf.Demo
 
         private void ShellTitleBar_BackRequested(object sender, EventArgs e)
         {
-            if (DemoNav != null && DemoNav.IsBackEnabled)
+            if (DemoNav is not null && DemoNav.IsBackEnabled)
             {
                 NavigateTo("home");
             }
@@ -608,7 +608,7 @@ namespace Fluence.Wpf.Demo
             _isUpdatingExtendedTitleOverlap = true;
             try
             {
-                if (!ExtendsContentIntoTitleBar || ShellTitleBar == null)
+                if (!ExtendsContentIntoTitleBar || ShellTitleBar is null)
                 {
                     return;
                 }
@@ -629,8 +629,8 @@ namespace Fluence.Wpf.Demo
                 }
 
                 System.Windows.Controls.TextBlock? titleText = GetTitleBarTemplatePart<System.Windows.Controls.TextBlock>("PART_TitleText");
-                if (titleText == null
-                    || NavSearchBox == null
+                if (titleText is null
+                    || NavSearchBox is null
                     || titleText.Visibility != Visibility.Visible
                     || NavSearchBox.Visibility != Visibility.Visible
                     || !titleText.IsVisible
@@ -658,13 +658,13 @@ namespace Fluence.Wpf.Demo
         private T? GetTitleBarTemplatePart<T>(string partName)
             where T : FrameworkElement
         {
-            if (ShellTitleBar == null)
+            if (ShellTitleBar is null)
             {
                 return null;
             }
 
             _ = ShellTitleBar.ApplyTemplate();
-            return ShellTitleBar.Template == null ? null : ShellTitleBar.Template.FindName(partName, ShellTitleBar) as T;
+            return ShellTitleBar.Template is null ? null : ShellTitleBar.Template.FindName(partName, ShellTitleBar) as T;
         }
 
     }

--- a/Fluence.Wpf.Demo/Pages/DemoSampleControl.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/DemoSampleControl.xaml.cs
@@ -221,7 +221,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void UpdateHeaderVisibility()
         {
-            if (TitleTextBlock == null || DescriptionTextBlock == null || HeaderPanel == null)
+            if (TitleTextBlock is null || DescriptionTextBlock is null || HeaderPanel is null)
             {
                 return;
             }
@@ -242,12 +242,12 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void UpdateSampleContentVisibility()
         {
-            if (SampleCard == null || SourceExpander == null)
+            if (SampleCard is null || SourceExpander is null)
             {
                 return;
             }
 
-            if (SampleContent == null)
+            if (SampleContent is null)
             {
                 SampleCard.Visibility = Visibility.Collapsed;
                 SourceExpander.BorderThickness = new Thickness(1);
@@ -606,7 +606,7 @@ namespace Fluence.Wpf.Demo.Pages
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(placeholder);
 #else
-            if (placeholder == null)
+            if (placeholder is null)
             {
                 throw new ArgumentNullException(nameof(placeholder));
             }
@@ -622,7 +622,7 @@ namespace Fluence.Wpf.Demo.Pages
             };
 
             FluenceCard? hostCard = FindAncestorCard(placeholder);
-            if (hostCard != null && hostCard.Content is UIElement sampleContent)
+            if (hostCard is not null && hostCard.Content is UIElement sampleContent)
             {
                 sample.Margin = hostCard.Margin;
                 sample.VerticalAlignment = hostCard.VerticalAlignment;
@@ -675,7 +675,7 @@ namespace Fluence.Wpf.Demo.Pages
         private static FluenceCard? FindAncestorCard(FrameworkElement element)
         {
             DependencyObject? current = element;
-            while (current != null)
+            while (current is not null)
             {
                 if (current is FluenceCard card)
                 {

--- a/Fluence.Wpf.Demo/Pages/GalleryAccessibilityPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryAccessibilityPage.xaml.cs
@@ -460,7 +460,7 @@ namespace Fluence.Wpf.Demo.Pages.Accessibility
 
         private void PopulateHcTable()
         {
-            if (HcMappingTable == null)
+            if (HcMappingTable is null)
             {
                 return;
             }
@@ -482,7 +482,7 @@ namespace Fluence.Wpf.Demo.Pages.Accessibility
 
         private void RtlToggle_Changed(object sender, RoutedEventArgs e)
         {
-            if (RtlDemoCard == null || RtlToggle == null)
+            if (RtlDemoCard is null || RtlToggle is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryDataBindingPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryDataBindingPage.xaml.cs
@@ -148,7 +148,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void AddItem_Click(object sender, RoutedEventArgs e)
         {
-            if (NewItemBox == null)
+            if (NewItemBox is null)
             {
                 return;
             }
@@ -177,7 +177,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
         private void RemoveItem_Click(object sender, RoutedEventArgs e)
         {
             var selected = BoundListView.SelectedItem as DataBindingSampleItem;
-            if (selected != null)
+            if (selected is not null)
             {
                 BoundListView.AnimateRemove(selected, UpdateCount);
             }
@@ -270,16 +270,16 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void SelectionMode_Changed(object sender, RoutedEventArgs e)
         {
-            if (SelectionModeListView == null)
+            if (SelectionModeListView is null)
             {
                 return;
             }
 
-            if (MultipleModeRadio != null && MultipleModeRadio.IsChecked == true)
+            if (MultipleModeRadio is not null && MultipleModeRadio.IsChecked == true)
             {
                 SelectionModeListView.SelectionMode = SelectionMode.Multiple;
             }
-            else if (ExtendedModeRadio != null && ExtendedModeRadio.IsChecked == true)
+            else if (ExtendedModeRadio is not null && ExtendedModeRadio.IsChecked == true)
             {
                 SelectionModeListView.SelectionMode = SelectionMode.Extended;
             }
@@ -299,7 +299,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void UpdateSelectionLabel()
         {
-            if (SelectionCountLabel == null || SelectionModeListView == null)
+            if (SelectionCountLabel is null || SelectionModeListView is null)
             {
                 return;
             }
@@ -433,7 +433,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void AddItem_Click(object sender, RoutedEventArgs e)
         {
-            if (NewItemBox == null)
+            if (NewItemBox is null)
             {
                 return;
             }
@@ -461,7 +461,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void RemoveItem_Click(object sender, RoutedEventArgs e)
         {
-            if (BoundListView == null)
+            if (BoundListView is null)
             {
                 return;
             }
@@ -497,7 +497,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void SelectionMode_Changed(object sender, RoutedEventArgs e)
         {
-            if (SelectionModeListView == null)
+            if (SelectionModeListView is null)
             {
                 return;
             }
@@ -517,7 +517,7 @@ namespace Fluence.Wpf.Demo.Pages.DataBinding
 
         private void UpdateSelectionLabel()
         {
-            if (SelectionCountLabel == null || SelectionModeListView == null)
+            if (SelectionCountLabel is null || SelectionModeListView is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml.cs
@@ -294,7 +294,7 @@ namespace Fluence.Wpf.Demo.Pages.Data
 
         private void AddListItem_Click(object sender, RoutedEventArgs e)
         {
-            if (EmptyStateListView == null)
+            if (EmptyStateListView is null)
             {
                 return;
             }
@@ -307,7 +307,7 @@ namespace Fluence.Wpf.Demo.Pages.Data
 
         private void RemoveListItem_Click(object sender, RoutedEventArgs e)
         {
-            if (EmptyStateListView == null || EmptyStateListView.Items.Count == 0)
+            if (EmptyStateListView is null || EmptyStateListView.Items.Count == 0)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryFormsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryFormsPage.xaml.cs
@@ -204,7 +204,7 @@ namespace Fluence.Wpf.Demo.Pages.Forms
 
         private void SignInField_Changed(object? sender, RoutedEventArgs e)
         {
-            if (SignInButton == null || SignInEmailBox == null || SignInPasswordBox == null)
+            if (SignInButton is null || SignInEmailBox is null || SignInPasswordBox is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryGlyphsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryGlyphsPage.xaml.cs
@@ -123,7 +123,7 @@ namespace Fluence.Wpf.Demo.Pages.Glyphs
         {
             lock (IconRowsLock)
             {
-                if (cachedIconRows == null)
+                if (cachedIconRows is null)
                 {
                     List<IconCatalogItem> icons = LoadIconCatalog();
                     cachedIconCount = icons.Count;
@@ -203,7 +203,7 @@ namespace Fluence.Wpf.Demo.Pages.Glyphs
             using (StreamReader reader = new(info.Stream, Encoding.UTF8, true))
             {
                 string? line;
-                while ((line = reader.ReadLine()) != null)
+                while ((line = reader.ReadLine()) is not null)
                 {
                     if (line.Length == 0)
                     {

--- a/Fluence.Wpf.Demo/Pages/GalleryHomePage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryHomePage.xaml.cs
@@ -99,10 +99,10 @@ namespace Fluence.Wpf.Demo.Pages
         private static bool IsCurrentBackgroundDark()
         {
             Application app = Application.Current;
-            SolidColorBrush? brush = app != null
+            SolidColorBrush? brush = app is not null
                 ? app.TryFindResource("SolidBackgroundFillColorBaseBrush") as SolidColorBrush
                 : null;
-            if (brush == null)
+            if (brush is null)
             {
                 return ApplicationThemeManager.CurrentTheme != ApplicationTheme.Light;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryInputsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryInputsPage.xaml.cs
@@ -299,12 +299,12 @@ namespace Fluence.Wpf.Demo.Pages.Inputs
 
         private void CharCountTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if (CharCountLabel == null || CharCountTextBox == null)
+            if (CharCountLabel is null || CharCountTextBox is null)
             {
                 return;
             }
 
-            int len = CharCountTextBox.Text != null ? CharCountTextBox.Text.Length : 0;
+            int len = CharCountTextBox.Text is not null ? CharCountTextBox.Text.Length : 0;
             CharCountLabel.Text = string.Format(CultureInfo.CurrentCulture, "Characters: {0}", len);
         }
     }

--- a/Fluence.Wpf.Demo/Pages/GalleryMenusPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryMenusPage.xaml.cs
@@ -120,7 +120,7 @@ namespace Fluence.Wpf.Demo.Pages.Menus
         private void MenuBar_Click(object sender, RoutedEventArgs e)
         {
             var element = sender as FrameworkElement;
-            var action = element != null ? element.Tag as string : null;
+            var action = element is not null ? element.Tag as string : null;
             MenuBarResultLabel.Text = string.Format(""Last menu action: {0}"", string.IsNullOrEmpty(action) ? ""None"" : action);
         }
     }
@@ -204,7 +204,7 @@ namespace Fluence.Wpf.Demo.Pages.Menus
         private void ContextMenu_Click(object sender, RoutedEventArgs e)
         {
             var element = sender as FrameworkElement;
-            var action = element != null ? element.Tag as string : null;
+            var action = element is not null ? element.Tag as string : null;
             ContextMenuResultLabel.Text = string.Format(""Last action: {0}"", string.IsNullOrEmpty(action) ? ""None"" : action);
         }
     }
@@ -364,7 +364,7 @@ namespace Fluence.Wpf.Demo.Pages.Menus
         private void FlyoutAction_Click(object sender, RoutedEventArgs e)
         {
             var element = sender as FrameworkElement;
-            var action = element != null ? element.Tag as string : null;
+            var action = element is not null ? element.Tag as string : null;
             FlyoutResultLabel.Text = string.Format(""Last action: {0}"", string.IsNullOrEmpty(action) ? ""None"" : action);
         }
     }

--- a/Fluence.Wpf.Demo/Pages/GalleryNavigationPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryNavigationPage.xaml.cs
@@ -217,14 +217,14 @@ namespace Fluence.Wpf.Demo.Pages.Navigation
 
         private void UpdateBackState()
         {
-            var isBackEnabled = BackEnabledToggle != null && BackEnabledToggle.IsChecked == true;
+            var isBackEnabled = BackEnabledToggle is not null && BackEnabledToggle.IsChecked == true;
 
-            if (CompactNavigationDemo != null)
+            if (CompactNavigationDemo is not null)
             {
                 CompactNavigationDemo.IsBackEnabled = isBackEnabled;
             }
 
-            if (BackStatusLabel != null)
+            if (BackStatusLabel is not null)
             {
                 BackStatusLabel.Text = isBackEnabled
                     ? string.Format(""Back button enabled ({0} requests)"", _backRequestCount)
@@ -268,7 +268,7 @@ namespace Fluence.Wpf.Demo.Pages.Navigation
 
         private static void SetNavigationDemoContent(NavigationView? nav, NavigationViewItem item)
         {
-            if (nav == null || item == null)
+            if (nav is null || item is null)
             {
                 return;
             }
@@ -337,7 +337,7 @@ namespace Fluence.Wpf.Demo.Pages.Navigation
 
         private void UpdateBackState()
         {
-            bool isBackEnabled = BackEnabledToggle != null && BackEnabledToggle.IsChecked == true;
+            bool isBackEnabled = BackEnabledToggle is not null && BackEnabledToggle.IsChecked == true;
 
             _ = (CompactNavigationDemo?.IsBackEnabled = isBackEnabled);
 

--- a/Fluence.Wpf.Demo/Pages/GallerySelectionPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GallerySelectionPage.xaml.cs
@@ -258,7 +258,7 @@ namespace Fluence.Wpf.Demo.Pages.Selection
 
         private void DefaultToggle_Changed(object? sender, RoutedEventArgs? e)
         {
-            if (ToggleStateLabel == null || DefaultToggle == null)
+            if (ToggleStateLabel is null || DefaultToggle is null)
             {
                 return;
             }
@@ -271,7 +271,7 @@ namespace Fluence.Wpf.Demo.Pages.Selection
 
         private void SelectionDemoCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (ComboStateLabel == null || SelectionDemoCombo == null)
+            if (ComboStateLabel is null || SelectionDemoCombo is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryStatusPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryStatusPage.xaml.cs
@@ -112,17 +112,17 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void ProgressSlider_ValueChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<double> e)
         {
-            if (ProgressSlider == null)
+            if (ProgressSlider is null)
             {
                 return;
             }
 
-            if (SliderValueLabel != null)
+            if (SliderValueLabel is not null)
             {
                 SliderValueLabel.Text = string.Format(""Value: {0:0}"", ProgressSlider.Value);
             }
 
-            if (StandardProgressBar != null)
+            if (StandardProgressBar is not null)
             {
                 StandardProgressBar.Value = ProgressSlider.Value;
             }
@@ -173,7 +173,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void IndeterminateToggle_Toggled(object sender, RoutedEventArgs e)
         {
-            if (IndeterminateProgressBar == null || IndeterminateToggle == null)
+            if (IndeterminateProgressBar is null || IndeterminateToggle is null)
             {
                 return;
             }
@@ -237,7 +237,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
         private void ProgressStep_Click(object sender, RoutedEventArgs e)
         {
             var button = sender as FrameworkElement;
-            var tag = button != null && button.Tag != null ? button.Tag.ToString() : string.Empty;
+            var tag = button is not null && button.Tag is not null ? button.Tag.ToString() : string.Empty;
 
             if (string.Equals(tag, ""Next"", StringComparison.OrdinalIgnoreCase))
             {
@@ -390,7 +390,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void ProgressRingSlider_ValueChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<double> e)
         {
-            if (DeterminateProgressRing != null && ProgressRingSlider != null)
+            if (DeterminateProgressRing is not null && ProgressRingSlider is not null)
             {
                 DeterminateProgressRing.Value = ProgressRingSlider.Value;
             }
@@ -495,7 +495,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void IndeterminateToggle_Toggled(object? sender, RoutedEventArgs? e)
         {
-            if (!IsLoaded || IndeterminateProgressBar == null || IndeterminateToggle == null)
+            if (!IsLoaded || IndeterminateProgressBar is null || IndeterminateToggle is null)
             {
                 return;
             }
@@ -507,7 +507,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void ProgressSlider_ValueChanged(object? sender, RoutedPropertyChangedEventArgs<double>? e)
         {
-            if (ProgressSlider == null)
+            if (ProgressSlider is null)
             {
                 return;
             }
@@ -519,7 +519,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void ProgressRingSlider_ValueChanged(object? sender, RoutedPropertyChangedEventArgs<double>? e)
         {
-            if (DeterminateProgressRing != null && ProgressRingSlider != null)
+            if (DeterminateProgressRing is not null && ProgressRingSlider is not null)
             {
                 DeterminateProgressRing.Value = ProgressRingSlider.Value;
             }
@@ -527,7 +527,7 @@ namespace Fluence.Wpf.Demo.Pages.Status
 
         private void ProgressStep_Click(object sender, RoutedEventArgs e)
         {
-            if (StepProgressBar == null)
+            if (StepProgressBar is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryTabsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryTabsPage.xaml.cs
@@ -277,7 +277,7 @@ namespace Fluence.Wpf.Demo.Pages.Tabs
         private void DemoTabView_TabCloseRequested(object sender, RoutedEventArgs e)
         {
             var args = e as TabViewTabCloseRequestedEventArgs;
-            if (args == null || args.Tab == null)
+            if (args is null || args.Tab is null)
             {
                 return;
             }
@@ -307,7 +307,7 @@ namespace Fluence.Wpf.Demo.Pages.Tabs
 
         private void DemoTabView_AddTabButtonClick(object sender, RoutedEventArgs e)
         {
-            if (DemoTabView == null)
+            if (DemoTabView is null)
             {
                 return;
             }
@@ -336,7 +336,7 @@ namespace Fluence.Wpf.Demo.Pages.Tabs
 
         private void DemoTabView_TabCloseRequested(object sender, RoutedEventArgs e)
         {
-            if (e is not TabViewTabCloseRequestedEventArgs args || DemoTabView == null || args.Tab == null)
+            if (e is not TabViewTabCloseRequestedEventArgs args || DemoTabView is null || args.Tab is null)
             {
                 return;
             }
@@ -347,7 +347,7 @@ namespace Fluence.Wpf.Demo.Pages.Tabs
 
         private void UpdateStatus()
         {
-            if (DemoTabViewStatus == null || DemoTabView == null)
+            if (DemoTabViewStatus is null || DemoTabView is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryTreesPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryTreesPage.xaml.cs
@@ -128,7 +128,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
         private void SelectionTreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
             var item = e.NewValue as FluenceTreeViewItem;
-            TreeSelectionLabel.Text = item == null
+            TreeSelectionLabel.Text = item is null
                 ? ""Selected: -""
                 : string.Format(""Selected: {0}"", BuildPath(item));
         }
@@ -137,7 +137,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
         {
             var header = item.Header as string ?? string.Empty;
             var parent = ItemsControl.ItemsControlFromItemContainer(item) as FluenceTreeViewItem;
-            if (parent == null)
+            if (parent is null)
             {
                 return header;
             }
@@ -213,7 +213,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
             foreach (var obj in items)
             {
                 var item = obj as FluenceTreeViewItem;
-                if (item == null)
+                if (item is null)
                 {
                     continue;
                 }
@@ -237,7 +237,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
 
         private void SelectionTreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
-            if (TreeSelectionLabel == null)
+            if (TreeSelectionLabel is null)
             {
                 return;
             }
@@ -254,7 +254,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
 
         private static string BuildPath(FluenceTreeViewItem item)
         {
-            if (item == null)
+            if (item is null)
             {
                 return string.Empty;
             }
@@ -273,7 +273,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
 
         private void ExpandAll_Click(object sender, RoutedEventArgs e)
         {
-            if (ExpansionTreeView == null)
+            if (ExpansionTreeView is null)
             {
                 return;
             }
@@ -283,7 +283,7 @@ namespace Fluence.Wpf.Demo.Pages.Trees
 
         private void CollapseAll_Click(object sender, RoutedEventArgs e)
         {
-            if (ExpansionTreeView == null)
+            if (ExpansionTreeView is null)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryWindowPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryWindowPage.xaml.cs
@@ -204,7 +204,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             var rb = sender as RadioButton;
-            if (rb == null)
+            if (rb is null)
             {
                 return;
             }
@@ -228,7 +228,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             var host = System.Windows.Window.GetWindow(this) as Fluence.Wpf.Controls.FluenceWindow;
-            var backdrop = host != null ? host.SystemBackdropType : BackdropType.Mica;
+            var backdrop = host is not null ? host.SystemBackdropType : BackdropType.Mica;
             ApplicationThemeManager.Apply(theme, backdrop, true);
             ThemeStateLabel.Text = string.Format(""Current: {0}"", theme);
         }
@@ -241,7 +241,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             var window = System.Windows.Window.GetWindow(this) as Fluence.Wpf.Controls.FluenceWindow;
-            if (window == null)
+            if (window is null)
             {
                 return;
             }
@@ -278,7 +278,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             var host = System.Windows.Window.GetWindow(this);
-            if (host == null)
+            if (host is null)
             {
                 return;
             }
@@ -298,7 +298,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
         private void AccentSwatch_Click(object sender, RoutedEventArgs e)
         {
             var button = sender as FrameworkElement;
-            var hex = button != null ? button.Tag as string : null;
+            var hex = button is not null ? button.Tag as string : null;
             if (string.IsNullOrEmpty(hex))
             {
                 return;
@@ -307,7 +307,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             try
             {
                 var converted = ColorConverter.ConvertFromString(hex);
-                if (converted != null)
+                if (converted is not null)
                 {
                     ApplicationAccentColorManager.ApplyCustomAccent((Color)converted);
                 }
@@ -442,7 +442,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             var window = HostFluenceWindow;
-            if (window == null)
+            if (window is null)
             {
                 return;
             }
@@ -455,13 +455,13 @@ namespace Fluence.Wpf.Demo.Pages.Window
         private void WindowChromeToggle_Changed(object sender, RoutedEventArgs e)
         {
             var window = HostFluenceWindow;
-            if (window == null)
+            if (window is null)
             {
                 return;
             }
 
-            window.ShowIcon = ShowWindowIconToggle != null && ShowWindowIconToggle.IsChecked == true;
-            window.ShowTitle = ShowWindowTitleToggle != null && ShowWindowTitleToggle.IsChecked == true;
+            window.ShowIcon = ShowWindowIconToggle is not null && ShowWindowIconToggle.IsChecked == true;
+            window.ShowTitle = ShowWindowTitleToggle is not null && ShowWindowTitleToggle.IsChecked == true;
         }
 
         private static void ApplyCaptionVisibility(
@@ -469,8 +469,8 @@ namespace Fluence.Wpf.Demo.Pages.Window
             Action<Visibility> setVisibility,
             Action<bool> setEnabled)
         {
-            var item = combo != null ? combo.SelectedItem as ComboBoxItem : null;
-            var content = item != null ? item.Content as string : null;
+            var item = combo is not null ? combo.SelectedItem as ComboBoxItem : null;
+            var content = item is not null ? item.Content as string : null;
 
             if (string.Equals(content, ""Hidden"", StringComparison.Ordinal))
             {
@@ -538,7 +538,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
         private void SyncBackdropComboFromWindow()
         {
             FluenceWindow? fw = HostFluenceWindow;
-            if (fw == null || BackdropCombo == null)
+            if (fw is null || BackdropCombo is null)
             {
                 return;
             }
@@ -580,7 +580,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
                     ? ApplicationTheme.Dark
                     : ReferenceEquals(rb, ThemeHighContrast) ? ApplicationTheme.HighContrast : ApplicationTheme.Auto;
             FluenceWindow? fw = HostFluenceWindow;
-            BackdropType backdrop = fw != null ? fw.SystemBackdropType : BackdropType.Mica;
+            BackdropType backdrop = fw is not null ? fw.SystemBackdropType : BackdropType.Mica;
             ApplicationThemeManager.Apply(theme, backdrop);
             UpdateThemeStateLabel(ApplicationThemeManager.CurrentTheme);
         }
@@ -593,7 +593,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             FluenceWindow? fw = HostFluenceWindow;
-            if (fw == null)
+            if (fw is null)
             {
                 return;
             }
@@ -612,7 +612,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
 
         private void AccentSwatch_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is not FrameworkElement button || button.Tag == null)
+            if (sender is not FrameworkElement button || button.Tag is null)
             {
                 return;
             }
@@ -621,7 +621,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             try
             {
                 object converted = ColorConverter.ConvertFromString(hex);
-                if (converted != null)
+                if (converted is not null)
                 {
                     ApplicationAccentColorManager.ApplyCustomAccent((Color)converted);
                 }
@@ -645,7 +645,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             FluenceWindow? host = HostFluenceWindow;
-            if (host == null)
+            if (host is null)
             {
                 return;
             }
@@ -670,7 +670,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
             }
 
             FluenceWindow? fw = HostFluenceWindow;
-            if (fw == null)
+            if (fw is null)
             {
                 return;
             }
@@ -684,7 +684,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
         private void WindowChromeToggle_Changed(object? sender, RoutedEventArgs? e)
         {
             FluenceWindow? fw = HostFluenceWindow;
-            if (fw == null)
+            if (fw is null)
             {
                 return;
             }
@@ -694,11 +694,11 @@ namespace Fluence.Wpf.Demo.Pages.Window
             // actual ShowIcon / ShowTitle DPs.
             MainWindow? main = fw as MainWindow;
 
-            if (ShowWindowTitleToggle != null)
+            if (ShowWindowTitleToggle is not null)
             {
                 bool show = ShowWindowTitleToggle.IsChecked == true;
                 string title = show ? MainWindow.GalleryWindowTitle : string.Empty;
-                if (main != null)
+                if (main is not null)
                 {
                     main.SetUserShowTitle(show, title);
                 }
@@ -709,13 +709,13 @@ namespace Fluence.Wpf.Demo.Pages.Window
                 }
             }
 
-            if (ShowWindowIconToggle != null)
+            if (ShowWindowIconToggle is not null)
             {
                 bool show = ShowWindowIconToggle.IsChecked == true;
                 ImageSource? icon = show
                     ? new BitmapImage(new Uri("pack://application:,,,/Fluence.Wpf.Demo;component/Resources/fluence-wpf-appicon-256.ico"))
                     : null;
-                if (main != null)
+                if (main is not null)
                 {
                     main.SetUserShowIcon(show, icon);
                 }
@@ -729,7 +729,7 @@ namespace Fluence.Wpf.Demo.Pages.Window
 
         private void SyncThemeRadioButtons()
         {
-            if (ThemeLight == null)
+            if (ThemeLight is null)
             {
                 return;
             }
@@ -773,8 +773,8 @@ namespace Fluence.Wpf.Demo.Pages.Window
             Action<Visibility> setVisibility,
             Action<bool> setEnabled)
         {
-            ComboBoxItem? item = combo != null ? combo.SelectedItem as ComboBoxItem : null;
-            string? content = item != null ? item.Content as string : null;
+            ComboBoxItem? item = combo is not null ? combo.SelectedItem as ComboBoxItem : null;
+            string? content = item is not null ? item.Content as string : null;
 
             if (string.Equals(content, "Hidden", StringComparison.Ordinal))
             {

--- a/Fluence.Wpf.Tests/ComboBoxTests.cs
+++ b/Fluence.Wpf.Tests/ComboBoxTests.cs
@@ -53,7 +53,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }

--- a/Fluence.Wpf.Tests/ControlRenderingTests.cs
+++ b/Fluence.Wpf.Tests/ControlRenderingTests.cs
@@ -53,7 +53,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }

--- a/Fluence.Wpf.Tests/ControlTests.CaptionButtons.cs
+++ b/Fluence.Wpf.Tests/ControlTests.CaptionButtons.cs
@@ -182,7 +182,7 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (window != null)
+                    if (window is not null)
                     {
                         // Restore before close so the dispatcher does not leak a minimized window.
                         window.WindowState = WindowState.Normal;

--- a/Fluence.Wpf.Tests/ControlTests.FluentStroke.cs
+++ b/Fluence.Wpf.Tests/ControlTests.FluentStroke.cs
@@ -104,7 +104,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -154,7 +154,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -206,7 +206,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -256,7 +256,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -324,7 +324,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -391,7 +391,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -437,7 +437,7 @@ namespace Fluence.Wpf.Tests
                     window.Content = null;
                     window.UpdateLayout();
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }

--- a/Fluence.Wpf.Tests/ControlTests.InfoBadge.cs
+++ b/Fluence.Wpf.Tests/ControlTests.InfoBadge.cs
@@ -62,7 +62,7 @@ namespace Fluence.Wpf.Tests
                 IList groups = VisualStateManager.GetVisualStateGroups(
                     FindVisualChild<Grid>(badge));
                 bool found = false;
-                if (groups != null)
+                if (groups is not null)
                 {
                     foreach (object? g in groups)
                     {
@@ -136,7 +136,7 @@ namespace Fluence.Wpf.Tests
 
                 IList groups = VisualStateManager.GetVisualStateGroups(FindVisualChild<Grid>(badge));
                 VisualStateGroup? dkg = null;
-                if (groups != null)
+                if (groups is not null)
                 {
                     foreach (object? g in groups)
                     {

--- a/Fluence.Wpf.Tests/ControlTests.NavigationView.cs
+++ b/Fluence.Wpf.Tests/ControlTests.NavigationView.cs
@@ -164,7 +164,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -203,7 +203,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -227,7 +227,7 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -274,7 +274,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -313,7 +313,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -369,7 +369,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -407,7 +407,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -449,7 +449,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -494,7 +494,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -565,7 +565,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -610,7 +610,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -655,7 +655,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -695,7 +695,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -740,7 +740,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -780,7 +780,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -824,7 +824,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -871,7 +871,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -920,7 +920,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -967,7 +967,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1026,7 +1026,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1089,7 +1089,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1154,7 +1154,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1219,7 +1219,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1276,7 +1276,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1320,7 +1320,7 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1369,7 +1369,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1413,7 +1413,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1463,7 +1463,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1512,7 +1512,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1568,7 +1568,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1613,7 +1613,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1656,7 +1656,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1699,7 +1699,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1743,7 +1743,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1793,7 +1793,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1838,7 +1838,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1880,7 +1880,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1939,7 +1939,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -1988,7 +1988,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2031,7 +2031,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2075,7 +2075,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2113,7 +2113,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2145,7 +2145,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2204,7 +2204,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2304,7 +2304,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(winTop);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2318,7 +2318,7 @@ namespace Fluence.Wpf.Tests
         /// </summary>
         private static void AssertBrushIsTransparentOrNull(Brush brush, string message)
         {
-            if (brush == null)
+            if (brush is null)
             {
                 return; // null == no background == transparent
             }
@@ -2418,7 +2418,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }

--- a/Fluence.Wpf.Tests/ControlTests.NumberBox.cs
+++ b/Fluence.Wpf.Tests/ControlTests.NumberBox.cs
@@ -83,7 +83,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -133,7 +133,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -183,7 +183,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -233,7 +233,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -317,7 +317,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     CloseWindowAndDrain(window);
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }

--- a/Fluence.Wpf.Tests/ControlTests.ScrollBar.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ScrollBar.cs
@@ -69,7 +69,7 @@ namespace Fluence.Wpf.Tests
                     }
                 }
 
-                if (state != null)
+                if (state is not null)
                 {
                     break;
                 }

--- a/Fluence.Wpf.Tests/ControlTests.cs
+++ b/Fluence.Wpf.Tests/ControlTests.cs
@@ -103,7 +103,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }
@@ -140,7 +140,7 @@ namespace Fluence.Wpf.Tests
 
         private static T? FindVisualChild<T>(DependencyObject root) where T : DependencyObject
         {
-            if (root == null)
+            if (root is null)
             {
                 return null;
             }
@@ -165,7 +165,7 @@ namespace Fluence.Wpf.Tests
 
         private static IEnumerable<T> FindVisualChildren<T>(DependencyObject root) where T : DependencyObject
         {
-            if (root == null)
+            if (root is null)
             {
                 yield break;
             }
@@ -188,7 +188,7 @@ namespace Fluence.Wpf.Tests
 
         private static DependencyObject? FindVisualChildByTypeName(DependencyObject root, string typeName)
         {
-            if (root == null)
+            if (root is null)
             {
                 return null;
             }
@@ -202,7 +202,7 @@ namespace Fluence.Wpf.Tests
             for (int index = 0; index < childCount; index++)
             {
                 DependencyObject? found = FindVisualChildByTypeName(VisualTreeHelper.GetChild(root, index), typeName);
-                if (found != null)
+                if (found is not null)
                 {
                     return found;
                 }
@@ -213,7 +213,7 @@ namespace Fluence.Wpf.Tests
 
         private static T? FindVisualChildByName<T>(DependencyObject root, string name) where T : FrameworkElement
         {
-            if (root == null || string.IsNullOrWhiteSpace(name))
+            if (root is null || string.IsNullOrWhiteSpace(name))
             {
                 return null;
             }
@@ -230,7 +230,7 @@ namespace Fluence.Wpf.Tests
                 }
 
                 T? found = FindVisualChildByName<T>(VisualTreeHelper.GetChild(root, index), name);
-                if (found != null)
+                if (found is not null)
                 {
                     return found;
                 }
@@ -242,7 +242,7 @@ namespace Fluence.Wpf.Tests
         private static StackPanel? GetNavigationViewItemsHostPanel(Controls.NavigationView nav)
         {
             ItemsPresenter? presenter = FindVisualChild<ItemsPresenter>(nav);
-            if (presenter == null)
+            if (presenter is null)
             {
                 return null;
             }
@@ -687,7 +687,7 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -2594,7 +2594,7 @@ namespace Fluence.Wpf.Tests
 
                     bool arcDataReady = WaitUntil(window.Dispatcher, 1000, delegate
                     {
-                        return indeterminateArc.Data != null;
+                        return indeterminateArc.Data is not null;
                     });
                     Assert.IsTrue(arcDataReady,
                         "PART_IndeterminateArc should have non-null Data for the caterpillar geometry.");
@@ -2657,11 +2657,11 @@ namespace Fluence.Wpf.Tests
             DrainDispatcher(dispatcher);
 
             Controls.NavigationViewItem? selected = nav.SelectedItem as Controls.NavigationViewItem;
-            string? selectedLabel = selected == null ? null : selected.Content as string;
-            string? selectedTag = selected == null ? null : selected.Tag as string;
+            string? selectedLabel = selected is null ? null : selected.Content as string;
+            string? selectedTag = selected is null ? null : selected.Tag as string;
             bool matchesRequest = string.Equals(selectedLabel, itemContent, StringComparison.OrdinalIgnoreCase) ||
-                (selectedTag != null && selectedTag.IndexOf(itemContent, StringComparison.OrdinalIgnoreCase) >= 0);
-            if (selected == null || nav.Content == null || !matchesRequest)
+                (selectedTag is not null && selectedTag.IndexOf(itemContent, StringComparison.OrdinalIgnoreCase) >= 0);
+            if (selected is null || nav.Content is null || !matchesRequest)
             {
                 Assert.Fail(string.Format("Navigation item '{0}' should exist.", itemContent));
             }
@@ -2680,8 +2680,8 @@ namespace Fluence.Wpf.Tests
             foreach (TextBlock textBlock in FindVisualChildren<TextBlock>(button))
             {
                 FontFamily fontFamily = textBlock.FontFamily;
-                if (fontFamily != null &&
-                    fontFamily.Source != null &&
+                if (fontFamily is not null &&
+                    fontFamily.Source is not null &&
                     fontFamily.Source.IndexOf("Segoe Fluent Icons", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     return textBlock;

--- a/Fluence.Wpf.Tests/DemoMainWindowTests.cs
+++ b/Fluence.Wpf.Tests/DemoMainWindowTests.cs
@@ -87,7 +87,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (captured != null)
+            if (captured is not null)
             {
                 ExceptionDispatchInfo.Capture(captured).Throw();
             }
@@ -1209,7 +1209,7 @@ namespace Fluence.Wpf.Tests
         private static IEnumerable<T> FindAllVisualChildren<T>(DependencyObject? root, HashSet<DependencyObject> visited)
             where T : DependencyObject
         {
-            if (root == null)
+            if (root is null)
             {
                 yield break;
             }

--- a/Fluence.Wpf.Tests/FluenceWindowHardenTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowHardenTests.cs
@@ -52,7 +52,7 @@ namespace Fluence.Wpf.Tests
                 catch (Exception ex) { captured = ex; }
             }));
 
-            if (captured != null)
+            if (captured is not null)
             {
                 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(captured).Throw();
             }

--- a/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
@@ -59,7 +59,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }
@@ -97,7 +97,7 @@ namespace Fluence.Wpf.Tests
                 {
                     window?.Close();
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -136,7 +136,7 @@ namespace Fluence.Wpf.Tests
                 {
                     window?.Close();
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -423,7 +423,7 @@ namespace Fluence.Wpf.Tests
 
                     ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, true);
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -456,7 +456,7 @@ namespace Fluence.Wpf.Tests
                     ApplicationThemeManager.Changed -= handler;
                     ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, true);
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -520,7 +520,7 @@ namespace Fluence.Wpf.Tests
                 {
                     ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, true);
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -553,7 +553,7 @@ namespace Fluence.Wpf.Tests
                 {
                     ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, true);
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -1126,7 +1126,7 @@ namespace Fluence.Wpf.Tests
                 {
                     window?.Close();
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -1218,7 +1218,7 @@ namespace Fluence.Wpf.Tests
 
                     _ = window.ShowDialog();
 
-                    if (scenarioException != null)
+                    if (scenarioException is not null)
                     {
                         ExceptionDispatchInfo.Capture(scenarioException).Throw();
                     }
@@ -1234,12 +1234,12 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (window != null && window.IsVisible)
+                    if (window is not null && window.IsVisible)
                     {
                         window.Close();
                     }
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -1267,7 +1267,7 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -1417,7 +1417,7 @@ namespace Fluence.Wpf.Tests
                 {
                     window?.Close();
 
-                    if (dict != null)
+                    if (dict is not null)
                     {
                         _ = app?.Resources.MergedDictionaries.Remove(dict);
                     }
@@ -1427,7 +1427,7 @@ namespace Fluence.Wpf.Tests
 
         private static DependencyObject? FindLogicalHost(DependencyObject node)
         {
-            while (node != null)
+            while (node is not null)
             {
                 if (node is System.Windows.Controls.Border or System.Windows.Controls.Button)
                 {
@@ -1442,7 +1442,7 @@ namespace Fluence.Wpf.Tests
 
         private static bool IsDescendantOfButton(DependencyObject node, System.Windows.Controls.Button target)
         {
-            while (node != null)
+            while (node is not null)
             {
                 if (ReferenceEquals(node, target))
                 {

--- a/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
+++ b/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
@@ -85,7 +85,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (captured != null)
+            if (captured is not null)
             {
                 ExceptionDispatchInfo.Capture(captured).Throw();
             }
@@ -104,7 +104,7 @@ namespace Fluence.Wpf.Tests
         private static string FindRepoRoot()
         {
             DirectoryInfo? directory = new(AppContext.BaseDirectory);
-            while (directory != null)
+            while (directory is not null)
             {
                 if (File.Exists(Path.Combine(directory.FullName, "Fluence.Wpf.sln")))
                 {

--- a/Fluence.Wpf.Tests/ListViewIsItemSelectableTests.cs
+++ b/Fluence.Wpf.Tests/ListViewIsItemSelectableTests.cs
@@ -55,7 +55,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }
@@ -129,7 +129,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -168,7 +168,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -208,7 +208,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -248,7 +248,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }

--- a/Fluence.Wpf.Tests/SplitButtonTests.cs
+++ b/Fluence.Wpf.Tests/SplitButtonTests.cs
@@ -57,7 +57,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }

--- a/Fluence.Wpf.Tests/TabViewTests.cs
+++ b/Fluence.Wpf.Tests/TabViewTests.cs
@@ -60,7 +60,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }
@@ -88,7 +88,7 @@ namespace Fluence.Wpf.Tests
 
         private static T? FindVisualChild<T>(DependencyObject root) where T : DependencyObject
         {
-            if (root == null)
+            if (root is null)
             {
                 return null;
             }
@@ -113,7 +113,7 @@ namespace Fluence.Wpf.Tests
 
         private static IEnumerable<T> FindVisualChildren<T>(DependencyObject root) where T : DependencyObject
         {
-            if (root == null)
+            if (root is null)
             {
                 yield break;
             }
@@ -136,7 +136,7 @@ namespace Fluence.Wpf.Tests
 
         private static T? FindVisualChildByName<T>(DependencyObject root, string name) where T : FrameworkElement
         {
-            if (root == null || string.IsNullOrWhiteSpace(name))
+            if (root is null || string.IsNullOrWhiteSpace(name))
             {
                 return null;
             }
@@ -153,7 +153,7 @@ namespace Fluence.Wpf.Tests
                 }
 
                 T? found = FindVisualChildByName<T>(VisualTreeHelper.GetChild(root, index), name);
-                if (found != null)
+                if (found is not null)
                 {
                     return found;
                 }
@@ -258,7 +258,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -323,7 +323,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -382,7 +382,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -418,7 +418,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -451,7 +451,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -495,7 +495,7 @@ namespace Fluence.Wpf.Tests
                 finally
                 {
                     window.Close();
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }

--- a/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
+++ b/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
@@ -308,7 +308,7 @@ namespace Fluence.Wpf.Tests
         private static void AssertStyleFluentFontFamilySetterOrBasedOn(Style style, string description)
         {
             Style current = style;
-            while (current != null)
+            while (current is not null)
             {
                 foreach (SetterBase? setterBase in current.Setters)
                 {
@@ -342,7 +342,7 @@ namespace Fluence.Wpf.Tests
         private static void AssertStyleSetterOrBasedOn(Style style, DependencyProperty property, object expectedValue, string description)
         {
             Style current = style;
-            while (current != null)
+            while (current is not null)
             {
                 foreach (SetterBase? setterBase in current.Setters)
                 {
@@ -375,7 +375,7 @@ namespace Fluence.Wpf.Tests
         private static string FindRepoRoot()
         {
             DirectoryInfo? directory = new(AppContext.BaseDirectory);
-            while (directory != null)
+            while (directory is not null)
             {
                 if (File.Exists(Path.Combine(directory.FullName, "Fluence.Wpf.sln")))
                 {

--- a/Fluence.Wpf.Tests/ThemeMetricsTests.cs
+++ b/Fluence.Wpf.Tests/ThemeMetricsTests.cs
@@ -49,7 +49,7 @@ namespace Fluence.Wpf.Tests
                 catch (Exception ex) { captured = ex; }
             }));
 
-            if (captured != null)
+            if (captured is not null)
             {
                 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(captured).Throw();
             }

--- a/Fluence.Wpf.Tests/TitleBarTests.cs
+++ b/Fluence.Wpf.Tests/TitleBarTests.cs
@@ -199,13 +199,13 @@ namespace Fluence.Wpf.Tests
                 }
                 finally
                 {
-                    if (window != null)
+                    if (window is not null)
                     {
                         window.Content = null;
                         window.Close();
                     }
 
-                    if (genericDictionary != null)
+                    if (genericDictionary is not null)
                     {
                         _ = application?.Resources.MergedDictionaries.Remove(genericDictionary);
                     }
@@ -243,7 +243,7 @@ namespace Fluence.Wpf.Tests
                 }
             }));
 
-            if (capturedException != null)
+            if (capturedException is not null)
             {
                 ExceptionDispatchInfo.Capture(capturedException).Throw();
             }

--- a/Fluence.Wpf.Tests/WpfTestSta.cs
+++ b/Fluence.Wpf.Tests/WpfTestSta.cs
@@ -48,7 +48,7 @@ namespace Fluence.Wpf.Tests
         {
             return Invoke(static () =>
             {
-                if (Application.Current == null)
+                if (Application.Current is null)
                 {
                     Application app = new()
                     {
@@ -74,7 +74,7 @@ namespace Fluence.Wpf.Tests
         {
             lock (LockObj)
             {
-                if (_dispatcher != null && _dispatcher.Thread.IsAlive)
+                if (_dispatcher is not null && _dispatcher.Thread.IsAlive)
                 {
                     return _dispatcher;
                 }

--- a/Fluence.Wpf/ApplicationAccentColorManager.cs
+++ b/Fluence.Wpf/ApplicationAccentColorManager.cs
@@ -206,7 +206,7 @@ namespace Fluence.Wpf
 
         internal static void UpdateThemeDependentColors(ApplicationTheme resolvedTheme)
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }
@@ -232,7 +232,7 @@ namespace Fluence.Wpf
 
         private static void UpdateTextOnAccentColors(ApplicationTheme resolvedTheme)
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }
@@ -297,7 +297,7 @@ namespace Fluence.Wpf
 
         private static void UpdateResources()
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }

--- a/Fluence.Wpf/ApplicationThemeManager.cs
+++ b/Fluence.Wpf/ApplicationThemeManager.cs
@@ -131,7 +131,7 @@ namespace Fluence.Wpf
 
         private static void InitializeDictionaries(ApplicationTheme resolvedTheme)
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }
@@ -157,7 +157,7 @@ namespace Fluence.Wpf
 
         private static void SwapThemeColors(ApplicationTheme resolvedTheme)
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }
@@ -210,7 +210,7 @@ namespace Fluence.Wpf
         /// </summary>
         private static void PromoteThemeColors(ApplicationTheme resolvedTheme)
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }
@@ -218,7 +218,7 @@ namespace Fluence.Wpf
             ResourceDictionary themeDict = resources.MergedDictionaries[SlotTheme];
             if (resolvedTheme != ApplicationTheme.HighContrast)
             {
-                if (_promotedHighContrastBrushKeys != null)
+                if (_promotedHighContrastBrushKeys is not null)
                 {
                     foreach (object key in _promotedHighContrastBrushKeys)
                     {
@@ -273,7 +273,7 @@ namespace Fluence.Wpf
 
         private static void OnChanged(ApplicationTheme resolvedTheme)
         {
-            if (Changed != null)
+            if (Changed is not null)
             {
                 Color accent = ApplicationAccentColorManager.SystemAccentColor;
                 Changed(null, new ThemeChangedEventArgs(resolvedTheme, accent));

--- a/Fluence.Wpf/Controls/Button.cs
+++ b/Fluence.Wpf/Controls/Button.cs
@@ -160,7 +160,7 @@ namespace Fluence.Wpf.Controls
                 ClearAutomaticToolTip();
                 return;
             }
-            if (_mainContentPresenter == null)
+            if (_mainContentPresenter is null)
             {
                 return;
             }
@@ -209,7 +209,7 @@ namespace Fluence.Wpf.Controls
 
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
         {
-            if (parent == null)
+            if (parent is null)
             {
                 return null;
             }

--- a/Fluence.Wpf/Controls/DockPanel.cs
+++ b/Fluence.Wpf/Controls/DockPanel.cs
@@ -95,7 +95,7 @@ namespace Fluence.Wpf.Controls
             for (int i = 0; i < lastIndex; i++)
             {
                 UIElement child = children[i];
-                if (child == null)
+                if (child is null)
                 {
                     continue;
                 }
@@ -127,7 +127,7 @@ namespace Fluence.Wpf.Controls
             if (lastFill && count > 0)
             {
                 UIElement child = children[count - 1];
-                if (child != null)
+                if (child is not null)
                 {
                     child.Measure(available);
                     Size desired = child.DesiredSize;
@@ -154,7 +154,7 @@ namespace Fluence.Wpf.Controls
             for (int i = 0; i < lastIndex; i++)
             {
                 UIElement child = children[i];
-                if (child == null)
+                if (child is null)
                 {
                     continue;
                 }

--- a/Fluence.Wpf/Controls/DropDownButton.cs
+++ b/Fluence.Wpf/Controls/DropDownButton.cs
@@ -148,7 +148,7 @@ namespace Fluence.Wpf.Controls
             _popup = null;
             base.OnApplyTemplate();
             _popup = GetTemplateChild(PART_Popup) as Popup;
-            if (_popup != null)
+            if (_popup is not null)
             {
                 _popup.PlacementTarget = this;
                 AttachPopupHandlers(_popup);
@@ -160,7 +160,7 @@ namespace Fluence.Wpf.Controls
         protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
         {
             base.OnPropertyChanged(e);
-            if (e.Property == IsCheckedProperty && _popup != null)
+            if (e.Property == IsCheckedProperty && _popup is not null)
             {
                 _popup.IsOpen = IsChecked == true;
             }

--- a/Fluence.Wpf/Controls/FluenceWindow.cs
+++ b/Fluence.Wpf/Controls/FluenceWindow.cs
@@ -75,7 +75,7 @@ namespace Fluence.Wpf.Controls
         {
             public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
             {
-                return value != null;
+                return value is not null;
             }
 
             public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -873,7 +873,7 @@ namespace Fluence.Wpf.Controls
                         mmi.ptMaxSize.Y = rcWork.Height;
 
                         double dpiX = 1.0, dpiY = 1.0;
-                        if (_hwndSource != null && _hwndSource.CompositionTarget != null)
+                        if (_hwndSource is not null && _hwndSource.CompositionTarget is not null)
                         {
                             Matrix transform = _hwndSource.CompositionTarget.TransformToDevice;
                             dpiX = transform.M11;
@@ -932,13 +932,13 @@ namespace Fluence.Wpf.Controls
                 {
                     if (WindowState == WindowState.Maximized)
                     {
-                        if (_restoreButton != null && _restoreButton.Visibility == Visibility.Visible && _restoreButton.IsEnabled)
+                        if (_restoreButton is not null && _restoreButton.Visibility == Visibility.Visible && _restoreButton.IsEnabled)
                         {
                             handled = true;
                             SystemCommands.RestoreWindow(this);
                         }
                     }
-                    else if (_maximizeButton != null && _maximizeButton.Visibility == Visibility.Visible && _maximizeButton.IsEnabled)
+                    else if (_maximizeButton is not null && _maximizeButton.Visibility == Visibility.Visible && _maximizeButton.IsEnabled)
                     {
                         handled = true;
                         SystemCommands.MaximizeWindow(this);
@@ -959,13 +959,13 @@ namespace Fluence.Wpf.Controls
                 return 0;
             }
 
-            if (_maximizeButton != null && _maximizeButton.Visibility == Visibility.Visible &&
+            if (_maximizeButton is not null && _maximizeButton.Visibility == Visibility.Visible &&
                 _maximizeButton.IsEnabled &&
                 IsOverElement(_maximizeButton, point))
             {
                 return NativeConstants.HTMAXBUTTON;
             }
-            if (_restoreButton != null && _restoreButton.Visibility == Visibility.Visible &&
+            if (_restoreButton is not null && _restoreButton.Visibility == Visibility.Visible &&
                 _restoreButton.IsEnabled &&
                 IsOverElement(_restoreButton, point))
             {
@@ -973,9 +973,9 @@ namespace Fluence.Wpf.Controls
             }
 
             // Minimize and close: return 0 so hit falls through to client area; WPF Button + Command fire.
-            if ((_minimizeButton != null && _minimizeButton.Visibility == Visibility.Visible &&
+            if ((_minimizeButton is not null && _minimizeButton.Visibility == Visibility.Visible &&
                  IsOverElement(_minimizeButton, point)) ||
-                (_closeButton != null && _closeButton.Visibility == Visibility.Visible &&
+                (_closeButton is not null && _closeButton.Visibility == Visibility.Visible &&
                  IsOverElement(_closeButton, point)))
             {
                 return 0;
@@ -995,7 +995,7 @@ namespace Fluence.Wpf.Controls
             }
 
             ClearSnapHover();
-            if (button != null && button.IsEnabled)
+            if (button is not null && button.IsEnabled)
             {
                 button.Background = TryFindResource("ControlStrongFillColorDefaultBrush") as Brush ?? Brushes.Transparent;
                 button.Foreground = TryFindResource("TextFillColorInverseBrush") as Brush ?? Brushes.White;
@@ -1005,7 +1005,7 @@ namespace Fluence.Wpf.Controls
 
         private void ClearSnapHover()
         {
-            if (_snapHoveredButton != null)
+            if (_snapHoveredButton is not null)
             {
                 _snapHoveredButton.Background = Brushes.Transparent;
                 _snapHoveredButton.ClearValue(ForegroundProperty);
@@ -1015,7 +1015,7 @@ namespace Fluence.Wpf.Controls
 
         private bool IsOverElement(UIElement element, Point windowPoint)
         {
-            if (element == null || element.Visibility != Visibility.Visible)
+            if (element is null || element.Visibility != Visibility.Visible)
             {
                 return false;
             }
@@ -1035,7 +1035,7 @@ namespace Fluence.Wpf.Controls
         private bool IsOverInteractiveContent(Point windowPoint)
         {
             DependencyObject? hit = InputHitTest(windowPoint) as DependencyObject;
-            while (hit != null)
+            while (hit is not null)
             {
                 if (hit is IInputElement element && WindowChrome.GetIsHitTestVisibleInChrome(element))
                 {

--- a/Fluence.Wpf/Controls/InfoBadge.cs
+++ b/Fluence.Wpf/Controls/InfoBadge.cs
@@ -140,7 +140,7 @@ namespace Fluence.Wpf.Controls
 
         private void UpdateDisplayKindState(bool useTransitions = true)
         {
-            string state = IconSource != null ? "Icon" : Value >= 0 ? "Value" : "Dot";
+            string state = IconSource is not null ? "Icon" : Value >= 0 ? "Value" : "Dot";
             _ = VisualStateManager.GoToState(this, state, useTransitions);
         }
     }

--- a/Fluence.Wpf/Controls/NavigationView.cs
+++ b/Fluence.Wpf/Controls/NavigationView.cs
@@ -354,7 +354,7 @@ namespace Fluence.Wpf.Controls
             _paneToggleButton = GetTemplateChild(PartPaneToggleButton) as System.Windows.Controls.Button;
             _paneToggleButton?.Click += OnPaneToggleButtonClick;
             _selectionIndicator = GetTemplateChild(PartSelectionIndicator) as FrameworkElement;
-            _indicatorHost = _selectionIndicator != null ? VisualTreeHelper.GetParent(_selectionIndicator) as FrameworkElement : null;
+            _indicatorHost = _selectionIndicator is not null ? VisualTreeHelper.GetParent(_selectionIndicator) as FrameworkElement : null;
             _indicatorPositioned = false;
             StopAnimation();
             UpdateBackButtonState(false);
@@ -385,7 +385,7 @@ namespace Fluence.Wpf.Controls
             }
 
             object fromContainer = ItemContainerGenerator.ItemFromContainer(navItem);
-            if (fromContainer != DependencyProperty.UnsetValue && fromContainer != null)
+            if (fromContainer != DependencyProperty.UnsetValue && fromContainer is not null)
             {
                 if (!ReferenceEquals(SelectedItem, fromContainer))
                 {
@@ -459,7 +459,7 @@ namespace Fluence.Wpf.Controls
 
         internal void InvokeItem(NavigationViewItem item)
         {
-            if (item == null || !item.IsEnabled)
+            if (item is null || !item.IsEnabled)
             {
                 return;
             }
@@ -496,7 +496,7 @@ namespace Fluence.Wpf.Controls
             bool isVisible = IsBackButtonVisible && IsBackEnabled;
             string stateName = isVisible ? "BackButtonVisible" : "BackButtonCollapsed";
             _ = VisualStateManager.GoToState(this, stateName, useTransitions);
-            if (_backButton != null)
+            if (_backButton is not null)
             {
                 _backButton.BeginAnimation(VisibilityProperty, null);
                 _backButton.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
@@ -524,7 +524,7 @@ namespace Fluence.Wpf.Controls
 
         private void OnNavigationViewItemLoaded(object sender, RoutedEventArgs e)
         {
-            if (SelectedItem != null)
+            if (SelectedItem is not null)
             {
                 ScheduleIndicatorPosition(false);
             }
@@ -575,7 +575,7 @@ namespace Fluence.Wpf.Controls
 
         private void PositionIndicator(bool animate, NavigationViewItem? previousItem)
         {
-            if (_selectionIndicator == null || _indicatorHost == null)
+            if (_selectionIndicator is null || _indicatorHost is null)
             {
                 return;
             }
@@ -583,7 +583,7 @@ namespace Fluence.Wpf.Controls
             {
                 return;
             }
-            if (SelectedItem == null)
+            if (SelectedItem is null)
             {
                 HideIndicator();
                 return;
@@ -639,7 +639,7 @@ namespace Fluence.Wpf.Controls
 
         private bool ShouldIndentSelectionIndicator(NavigationViewItem item, bool topMode)
         {
-            return !topMode && item != null && item.IsChildItem && (IsPaneOpen || (PaneDisplayMode != NavigationViewPaneDisplayMode.Left && PaneDisplayMode != NavigationViewPaneDisplayMode.LeftCompact));
+            return !topMode && item is not null && item.IsChildItem && (IsPaneOpen || (PaneDisplayMode != NavigationViewPaneDisplayMode.Left && PaneDisplayMode != NavigationViewPaneDisplayMode.LeftCompact));
         }
 
         private Point GetCurrentIndicatorPosition()
@@ -804,7 +804,7 @@ namespace Fluence.Wpf.Controls
             if (topMode)
             {
                 double x = fromPosition.X + (direction * length);
-                if (previousItem != null && previousItem.IsVisible && previousItem.ActualWidth > 0)
+                if (previousItem is not null && previousItem.IsVisible && previousItem.ActualWidth > 0)
                 {
                     try
                     {
@@ -821,7 +821,7 @@ namespace Fluence.Wpf.Controls
             }
 
             double y = fromPosition.Y + (direction * length);
-            if (previousItem != null && previousItem.IsVisible && previousItem.ActualHeight > 0)
+            if (previousItem is not null && previousItem.IsVisible && previousItem.ActualHeight > 0)
             {
                 try
                 {
@@ -847,7 +847,7 @@ namespace Fluence.Wpf.Controls
             if (topMode)
             {
                 double x = toPosition.X - (direction * length);
-                if (targetItem != null && targetItem.IsVisible && targetItem.ActualWidth > 0)
+                if (targetItem is not null && targetItem.IsVisible && targetItem.ActualWidth > 0)
                 {
                     try
                     {
@@ -865,7 +865,7 @@ namespace Fluence.Wpf.Controls
             }
 
             double y = toPosition.Y - (direction * length);
-            if (targetItem != null && targetItem.IsVisible && targetItem.ActualHeight > 0)
+            if (targetItem is not null && targetItem.IsVisible && targetItem.ActualHeight > 0)
             {
                 try
                 {
@@ -906,7 +906,7 @@ namespace Fluence.Wpf.Controls
         private void StopAnimation()
         {
             _indicatorAnimationGeneration++;
-            if (_selectionIndicator == null)
+            if (_selectionIndicator is null)
             {
                 return;
             }
@@ -932,7 +932,7 @@ namespace Fluence.Wpf.Controls
         /// </summary>
         private void EnsureMutableTransform()
         {
-            if (_selectionIndicator == null)
+            if (_selectionIndicator is null)
             {
                 return;
             }
@@ -963,7 +963,7 @@ namespace Fluence.Wpf.Controls
 
         internal void SelectItemFromContainer(NavigationViewItem navItem)
         {
-            if (navItem == null)
+            if (navItem is null)
             {
                 return;
             }
@@ -977,13 +977,13 @@ namespace Fluence.Wpf.Controls
         private object GetDataFromContainer(NavigationViewItem navItem)
         {
             object data = ItemContainerGenerator.ItemFromContainer(navItem);
-            return (data != DependencyProperty.UnsetValue && data != null) ? data : navItem;
+            return (data != DependencyProperty.UnsetValue && data is not null) ? data : navItem;
         }
 
         private static NavigationViewItem? FindNavigationViewItem(DependencyObject? focused)
         {
             DependencyObject? current = focused;
-            while (current != null)
+            while (current is not null)
             {
                 if (current is NavigationViewItem asItem)
                 {

--- a/Fluence.Wpf/Controls/NumberBox.cs
+++ b/Fluence.Wpf/Controls/NumberBox.cs
@@ -349,7 +349,7 @@ namespace Fluence.Wpf.Controls
         protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
         {
             base.OnGotKeyboardFocus(e);
-            if (_partTextBox != null && !_partTextBox.IsKeyboardFocusWithin)
+            if (_partTextBox is not null && !_partTextBox.IsKeyboardFocusWithin)
             {
                 _ = _partTextBox.Focus();
             }
@@ -359,7 +359,7 @@ namespace Fluence.Wpf.Controls
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
         {
             base.OnPreviewMouseLeftButtonDown(e);
-            if (_partTextBox != null && !_partTextBox.IsKeyboardFocusWithin)
+            if (_partTextBox is not null && !_partTextBox.IsKeyboardFocusWithin)
             {
                 _ = _partTextBox.Focus();
             }
@@ -369,7 +369,7 @@ namespace Fluence.Wpf.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            if (_partTextBox != null)
+            if (_partTextBox is not null)
             {
                 _partTextBox.KeyDown -= OnPartTextBoxKeyDown;
                 _partTextBox.LostKeyboardFocus -= OnPartTextBoxLostKeyboardFocus;
@@ -379,7 +379,7 @@ namespace Fluence.Wpf.Controls
             _partTextBox = GetTemplateChild(PartTextBox) as System.Windows.Controls.TextBox;
             _partUpButton = GetTemplateChild(PartUpButton) as System.Windows.Controls.Primitives.RepeatButton;
             _partDownButton = GetTemplateChild(PartDownButton) as System.Windows.Controls.Primitives.RepeatButton;
-            if (_partTextBox != null)
+            if (_partTextBox is not null)
             {
                 _partTextBox.KeyDown += OnPartTextBoxKeyDown;
                 _partTextBox.LostKeyboardFocus += OnPartTextBoxLostKeyboardFocus;
@@ -422,7 +422,7 @@ namespace Fluence.Wpf.Controls
             {
                 return;
             }
-            if (box._partTextBox != null && !string.Equals(box._partTextBox.Text, box.Text, StringComparison.Ordinal))
+            if (box._partTextBox is not null && !string.Equals(box._partTextBox.Text, box.Text, StringComparison.Ordinal))
             {
                 box._partTextBox.Text = box.Text ?? string.Empty;
             }
@@ -471,7 +471,7 @@ namespace Fluence.Wpf.Controls
             try
             {
                 SetCurrentValue(TextProperty, formatted);
-                if (_partTextBox != null && !string.Equals(_partTextBox.Text, formatted, StringComparison.Ordinal))
+                if (_partTextBox is not null && !string.Equals(_partTextBox.Text, formatted, StringComparison.Ordinal))
                 {
                     _partTextBox.Text = formatted;
                 }

--- a/Fluence.Wpf/Controls/PasswordBox.cs
+++ b/Fluence.Wpf/Controls/PasswordBox.cs
@@ -270,7 +270,7 @@ namespace Fluence.Wpf.Controls
         /// </summary>
         public void SelectAll()
         {
-            if (IsPasswordRevealed && _revealTextBox != null)
+            if (IsPasswordRevealed && _revealTextBox is not null)
             {
                 _revealTextBox.SelectAll();
             }
@@ -291,21 +291,21 @@ namespace Fluence.Wpf.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            if (_passwordBox != null)
+            if (_passwordBox is not null)
             {
                 _passwordBox.PasswordChanged -= OnPasswordBoxPasswordChanged;
                 _passwordBox.GotKeyboardFocus -= OnInnerKeyboardFocusChanged;
                 _passwordBox.LostKeyboardFocus -= OnInnerKeyboardFocusChanged;
                 _passwordBox.PreviewKeyDown -= OnInnerPreviewKeyDown;
             }
-            if (_revealTextBox != null)
+            if (_revealTextBox is not null)
             {
                 _revealTextBox.TextChanged -= OnRevealTextBoxTextChanged;
                 _revealTextBox.GotKeyboardFocus -= OnInnerKeyboardFocusChanged;
                 _revealTextBox.LostKeyboardFocus -= OnInnerKeyboardFocusChanged;
                 _revealTextBox.PreviewKeyDown -= OnInnerPreviewKeyDown;
             }
-            if (_revealButton != null)
+            if (_revealButton is not null)
             {
                 _revealButton.PreviewMouseLeftButtonDown -= OnRevealButtonDown;
                 _revealButton.PreviewMouseLeftButtonUp -= OnRevealButtonUp;
@@ -316,29 +316,29 @@ namespace Fluence.Wpf.Controls
             _passwordBox = GetTemplateChild("PART_PasswordBox") as System.Windows.Controls.PasswordBox;
             _revealTextBox = GetTemplateChild("PART_RevealTextBox") as System.Windows.Controls.TextBox;
             _revealButton = GetTemplateChild("PART_RevealButton") as System.Windows.Controls.Button;
-            if (_passwordBox != null)
+            if (_passwordBox is not null)
             {
                 _passwordBox.PasswordChanged += OnPasswordBoxPasswordChanged;
                 _passwordBox.Password = Password ?? string.Empty;
             }
-            if (_revealTextBox != null)
+            if (_revealTextBox is not null)
             {
                 _revealTextBox.TextChanged += OnRevealTextBoxTextChanged;
                 _revealTextBox.Text = Password ?? string.Empty;
             }
-            if (_revealButton != null)
+            if (_revealButton is not null)
             {
                 _revealButton.PreviewMouseLeftButtonDown += OnRevealButtonDown;
                 _revealButton.PreviewMouseLeftButtonUp += OnRevealButtonUp;
                 _revealButton.MouseLeave += OnRevealButtonLeave;
             }
-            if (_passwordBox != null)
+            if (_passwordBox is not null)
             {
                 _passwordBox.GotKeyboardFocus += OnInnerKeyboardFocusChanged;
                 _passwordBox.LostKeyboardFocus += OnInnerKeyboardFocusChanged;
                 _passwordBox.PreviewKeyDown += OnInnerPreviewKeyDown;
             }
-            if (_revealTextBox != null)
+            if (_revealTextBox is not null)
             {
                 _revealTextBox.GotKeyboardFocus += OnInnerKeyboardFocusChanged;
                 _revealTextBox.LostKeyboardFocus += OnInnerKeyboardFocusChanged;
@@ -377,7 +377,7 @@ namespace Fluence.Wpf.Controls
 
         private void StartCapsPoll()
         {
-            if (_capsPollTimer != null)
+            if (_capsPollTimer is not null)
             {
                 return;
             }
@@ -388,7 +388,7 @@ namespace Fluence.Wpf.Controls
 
         private void StopCapsPoll()
         {
-            if (_capsPollTimer == null)
+            if (_capsPollTimer is null)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/PersonPicture.cs
+++ b/Fluence.Wpf/Controls/PersonPicture.cs
@@ -255,7 +255,7 @@ namespace Fluence.Wpf.Controls
             if (IsGroup)
             {
                 // Group: show people glyph
-                if (_initialsText != null)
+                if (_initialsText is not null)
                 {
                     _initialsText.Text = GlyphPeople;
                     _initialsText.SetResourceReference(WpfTextBlock.FontFamilyProperty, "FluentFontFamily");
@@ -263,7 +263,7 @@ namespace Fluence.Wpf.Controls
                 _ = VisualStateManager.GoToState(this, StateGroup, useTransitions);
                 return;
             }
-            if (ProfilePicture != null)
+            if (ProfilePicture is not null)
             {
                 // Photo state: fill the image ellipse
                 _ = (_imageEllipse?.Fill = new ImageBrush(ProfilePicture) { Stretch = Stretch.UniformToFill });
@@ -274,7 +274,7 @@ namespace Fluence.Wpf.Controls
             if (GetInitials() is string initials)
             {
                 // Initials state
-                if (_initialsText != null)
+                if (_initialsText is not null)
                 {
                     _initialsText.Text = initials;
                     _initialsText.SetResourceReference(WpfTextBlock.FontFamilyProperty, "FluentFontFamily");
@@ -284,7 +284,7 @@ namespace Fluence.Wpf.Controls
             }
 
             // No photo or initials: show contact glyph (Segoe Fluent Icons U+E77B)
-            if (_initialsText != null)
+            if (_initialsText is not null)
             {
                 _initialsText.Text = GlyphContact;
                 _initialsText.FontFamily = new FontFamily("Segoe Fluent Icons");
@@ -296,7 +296,7 @@ namespace Fluence.Wpf.Controls
         {
             bool hasBadge = !string.IsNullOrWhiteSpace(BadgeGlyph) || BadgeNumber > 0;
             _ = (_badgeGrid?.Visibility = hasBadge ? Visibility.Visible : Visibility.Collapsed);
-            if (_badgeText != null)
+            if (_badgeText is not null)
             {
                 if (!string.IsNullOrWhiteSpace(BadgeGlyph))
                 {

--- a/Fluence.Wpf/Controls/ProgressBar.cs
+++ b/Fluence.Wpf/Controls/ProgressBar.cs
@@ -255,7 +255,7 @@ namespace Fluence.Wpf.Controls
 
         private void ApplyProgressMode()
         {
-            if (_fill == null || _indeterminateBar == null)
+            if (_fill is null || _indeterminateBar is null)
             {
                 return;
             }
@@ -282,7 +282,7 @@ namespace Fluence.Wpf.Controls
 
         private void ApplyFillBrushForMode()
         {
-            if (_fill == null)
+            if (_fill is null)
             {
                 return;
             }
@@ -308,7 +308,7 @@ namespace Fluence.Wpf.Controls
 
         private void RefreshIndeterminateLayout()
         {
-            if (_track == null || _indeterminateBar == null || ProgressMode != ProgressBarMode.Indeterminate)
+            if (_track is null || _indeterminateBar is null || ProgressMode != ProgressBarMode.Indeterminate)
             {
                 return;
             }
@@ -325,7 +325,7 @@ namespace Fluence.Wpf.Controls
         private void StartIndeterminate(double trackWidth)
         {
             StopIndeterminate();
-            if (_indeterminateTranslate == null || _indeterminateBar == null)
+            if (_indeterminateTranslate is null || _indeterminateBar is null)
             {
                 return;
             }
@@ -334,7 +334,7 @@ namespace Fluence.Wpf.Controls
             // Bar 1 travels 0 to 1.5 s then holds; bar 2 is delayed 0.75 s.
             // (Authority: WinUI_XAML/Controls/ProgressBar.xaml Indeterminate VSM)
             StartTranslateAnimation(_indeterminateTranslate, -_indeterminateBar.Width, trackWidth, TimeSpan.FromSeconds(2.0), TimeSpan.Zero);
-            if (_indeterminateTranslate2 != null && _indeterminateBar2 != null)
+            if (_indeterminateTranslate2 is not null && _indeterminateBar2 is not null)
             {
                 StartTranslateAnimation(_indeterminateTranslate2, -_indeterminateBar2.Width, trackWidth, TimeSpan.FromSeconds(2.0), TimeSpan.FromMilliseconds(750));
             }
@@ -355,12 +355,12 @@ namespace Fluence.Wpf.Controls
 
         private void StopIndeterminate()
         {
-            if (_indeterminateTranslate != null)
+            if (_indeterminateTranslate is not null)
             {
                 _indeterminateTranslate.BeginAnimation(TranslateTransform.XProperty, null);
                 _indeterminateTranslate.X = 0;
             }
-            if (_indeterminateTranslate2 != null)
+            if (_indeterminateTranslate2 is not null)
             {
                 _indeterminateTranslate2.BeginAnimation(TranslateTransform.XProperty, null);
                 _indeterminateTranslate2.X = 0;
@@ -369,7 +369,7 @@ namespace Fluence.Wpf.Controls
 
         private void UpdateFillWidth(bool animate = true)
         {
-            if (_track == null || _fill == null || ProgressMode == ProgressBarMode.Indeterminate)
+            if (_track is null || _fill is null || ProgressMode == ProgressBarMode.Indeterminate)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/ProgressRing.cs
+++ b/Fluence.Wpf/Controls/ProgressRing.cs
@@ -451,7 +451,7 @@ namespace Fluence.Wpf.Controls
             // initial frame synchronously.  Tweening here would race with the layout pass
             // and leave the arc blank when the dispatcher drains mid-animation.
             double targetFraction = ring.ComputeFraction();
-            if (ring._arcPath == null)
+            if (ring._arcPath is null)
             {
                 ring.AnimatedFraction = targetFraction;
                 return;
@@ -506,7 +506,7 @@ namespace Fluence.Wpf.Controls
 
         private void StartIndeterminateAnimation()
         {
-            if (_indeterminateArcPath == null)
+            if (_indeterminateArcPath is null)
             {
                 return;
             }
@@ -604,7 +604,7 @@ namespace Fluence.Wpf.Controls
 
         private void RenderIndeterminateArc()
         {
-            if (_indeterminateArcPath == null)
+            if (_indeterminateArcPath is null)
             {
                 return;
             }
@@ -618,7 +618,7 @@ namespace Fluence.Wpf.Controls
 
         private void RenderDeterminateArc(double fraction)
         {
-            if (_arcPath == null)
+            if (_arcPath is null)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/RatingControl.cs
+++ b/Fluence.Wpf/Controls/RatingControl.cs
@@ -195,7 +195,7 @@ namespace Fluence.Wpf.Controls
 
         private void BuildAndRefreshStars()
         {
-            if (_starsPanel == null)
+            if (_starsPanel is null)
             {
                 return;
             }
@@ -258,7 +258,7 @@ namespace Fluence.Wpf.Controls
 
         private void RefreshStars()
         {
-            if (_starsPanel == null)
+            if (_starsPanel is null)
             {
                 return;
             }
@@ -291,7 +291,7 @@ namespace Fluence.Wpf.Controls
 
         private void UpdateCaption()
         {
-            if (_captionText == null)
+            if (_captionText is null)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/SplitButton.cs
+++ b/Fluence.Wpf/Controls/SplitButton.cs
@@ -301,17 +301,17 @@ namespace Fluence.Wpf.Controls
             _secondaryButton = GetTemplateChild(PART_SecondaryButton) as System.Windows.Controls.Primitives.ToggleButton;
             _popup = GetTemplateChild(PART_Popup) as Popup;
             _primaryButton?.Click += OnPrimaryButtonClick;
-            if (_secondaryButton != null)
+            if (_secondaryButton is not null)
             {
                 _secondaryButton.Checked += OnSecondaryButtonChecked;
                 _secondaryButton.Unchecked += OnSecondaryButtonUnchecked;
             }
-            if (_popup != null)
+            if (_popup is not null)
             {
                 _popup.StaysOpen = false;
                 _popup.PlacementTarget = this;
                 _popup.Closed += OnPopupClosed;
-                _popup.IsOpen = _secondaryButton != null && _secondaryButton.IsChecked == true;
+                _popup.IsOpen = _secondaryButton is not null && _secondaryButton.IsChecked == true;
             }
         }
 
@@ -320,7 +320,7 @@ namespace Fluence.Wpf.Controls
             // Primary half: raise Click and invoke Command.
             RaiseEvent(new RoutedEventArgs(ClickEvent, this));
             ICommand command = Command;
-            if (command == null)
+            if (command is null)
             {
                 return;
             }
@@ -355,7 +355,7 @@ namespace Fluence.Wpf.Controls
         private void OnPopupClosed(object? sender, EventArgs e)
         {
             // External click (StaysOpen=false) closed the popup; sync the secondary toggle.
-            if (_secondaryButton != null && _secondaryButton.IsChecked == true)
+            if (_secondaryButton is not null && _secondaryButton.IsChecked == true)
             {
                 _secondaryButton.IsChecked = false;
             }
@@ -373,7 +373,7 @@ namespace Fluence.Wpf.Controls
 
         private void DetachSecondaryHandler()
         {
-            if (_secondaryButton != null)
+            if (_secondaryButton is not null)
             {
                 _secondaryButton.Checked -= OnSecondaryButtonChecked;
                 _secondaryButton.Unchecked -= OnSecondaryButtonUnchecked;

--- a/Fluence.Wpf/Controls/StackPanel.cs
+++ b/Fluence.Wpf/Controls/StackPanel.cs
@@ -75,7 +75,7 @@ namespace Fluence.Wpf.Controls
                 for (int i = 0; i < count; i++)
                 {
                     UIElement child = children[i];
-                    if (child == null)
+                    if (child is null)
                     {
                         continue;
                     }
@@ -97,7 +97,7 @@ namespace Fluence.Wpf.Controls
             for (int i = 0; i < count; i++)
             {
                 UIElement child = children[i];
-                if (child == null)
+                if (child is null)
                 {
                     continue;
                 }
@@ -128,7 +128,7 @@ namespace Fluence.Wpf.Controls
                 for (int i = 0; i < count; i++)
                 {
                     UIElement child = children[i];
-                    if (child == null)
+                    if (child is null)
                     {
                         continue;
                     }
@@ -148,7 +148,7 @@ namespace Fluence.Wpf.Controls
             for (int i = 0; i < count; i++)
             {
                 UIElement child = children[i];
-                if (child == null)
+                if (child is null)
                 {
                     continue;
                 }

--- a/Fluence.Wpf/Controls/TabView.cs
+++ b/Fluence.Wpf/Controls/TabView.cs
@@ -202,7 +202,7 @@ namespace Fluence.Wpf.Controls
             _addTabButton?.Click += OnAddTabButtonClick;
             _scrollBackButton?.Click += OnScrollBackClick;
             _scrollForwardButton?.Click += OnScrollForwardClick;
-            if (_tabContentScroller != null)
+            if (_tabContentScroller is not null)
             {
                 _tabContentScroller.ScrollChanged += OnTabScrollChanged;
                 UpdateScrollButtonVisibility();
@@ -243,7 +243,7 @@ namespace Fluence.Wpf.Controls
 
         private void UpdateScrollButtonVisibility()
         {
-            if (_tabContentScroller == null)
+            if (_tabContentScroller is null)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/TextBlock.cs
+++ b/Fluence.Wpf/Controls/TextBlock.cs
@@ -157,7 +157,7 @@ namespace Fluence.Wpf.Controls
 
         private void SyncPartTextBlock()
         {
-            if (_partTextBlock == null)
+            if (_partTextBlock is null)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/TextBox.cs
+++ b/Fluence.Wpf/Controls/TextBox.cs
@@ -294,7 +294,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
             counter.Visibility = Visibility.Visible;
-            counter.Text = string.Format(CultureInfo.CurrentCulture, "{0}/{1}", Text != null ? Text.Length : 0, MaxLength);
+            counter.Text = string.Format(CultureInfo.CurrentCulture, "{0}/{1}", Text is not null ? Text.Length : 0, MaxLength);
         }
 
         private void UpdateHelperText()
@@ -310,7 +310,7 @@ namespace Fluence.Wpf.Controls
                 string message = !string.IsNullOrWhiteSpace(ValidationMessage) ? ValidationMessage : HelperText;
                 helper.Text = message;
                 helper.Visibility = string.IsNullOrWhiteSpace(message) ? Visibility.Collapsed : Visibility.Visible;
-                if (icon != null)
+                if (icon is not null)
                 {
                     icon.Visibility = helper.Visibility;
                     switch (ValidationState)

--- a/Fluence.Wpf/Controls/TitleBar.cs
+++ b/Fluence.Wpf/Controls/TitleBar.cs
@@ -327,7 +327,7 @@ namespace Fluence.Wpf.Controls
         private static void OnCustomContentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             TitleBar titleBar = (TitleBar)d;
-            if (titleBar.Content == null || Equals(titleBar.Content, e.OldValue))
+            if (titleBar.Content is null || Equals(titleBar.Content, e.OldValue))
             {
                 titleBar.Content = e.NewValue;
             }
@@ -399,7 +399,7 @@ namespace Fluence.Wpf.Controls
 
         private static bool TryExecuteCommand(ICommand command, object parameter)
         {
-            if (command == null)
+            if (command is null)
             {
                 return true;
             }
@@ -413,7 +413,7 @@ namespace Fluence.Wpf.Controls
 
         private static bool CanExecuteCommand(ICommand command, object parameter)
         {
-            return command == null || command.CanExecute(parameter);
+            return command is null || command.CanExecute(parameter);
         }
 
         private static void SubscribeCommand(ICommand? command, EventHandler handler)

--- a/Fluence.Wpf/Helpers/AcrylicNoiseHelper.cs
+++ b/Fluence.Wpf/Helpers/AcrylicNoiseHelper.cs
@@ -37,7 +37,7 @@ namespace Fluence.Wpf.Helpers
     {
         internal static ImageBrush GetNoiseBrush()
         {
-            if (_cachedBrush != null)
+            if (_cachedBrush is not null)
             {
                 return _cachedBrush;
             }

--- a/Fluence.Wpf/Helpers/GridLengthAnimation.cs
+++ b/Fluence.Wpf/Helpers/GridLengthAnimation.cs
@@ -126,7 +126,7 @@ namespace Fluence.Wpf.Helpers
             // from the property's current animated base value — this is what WPF does
             // for a DoubleAnimation with only To set, and is what keeps a reverse
             // collapse (280 -> 48) from snapping to 0 on the first frame.
-            if (animationClock == null)
+            if (animationClock is null)
             {
                 throw new ArgumentNullException(nameof(animationClock));
             }
@@ -143,7 +143,7 @@ namespace Fluence.Wpf.Helpers
                 fromValue = fromLength.Value;
             }
             double progress = animationClock.CurrentProgress ?? 0d;
-            if (EasingFunction != null)
+            if (EasingFunction is not null)
             {
                 progress = EasingFunction.Ease(progress);
             }

--- a/Fluence.Wpf/SystemThemeWatcher.cs
+++ b/Fluence.Wpf/SystemThemeWatcher.cs
@@ -49,13 +49,13 @@ namespace Fluence.Wpf
         /// <exception cref="ArgumentNullException"><paramref name="window"/> is <c>null</c>.</exception>
         public static void Watch(Window window)
         {
-            if (window == null)
+            if (window is null)
             {
                 throw new ArgumentNullException(nameof(window));
             }
             lock (_lock)
             {
-                if (FindWatchedWindow(window) != null)
+                if (FindWatchedWindow(window) is not null)
                 {
                     return;
                 }
@@ -81,7 +81,7 @@ namespace Fluence.Wpf
         /// <exception cref="ArgumentNullException"><paramref name="window"/> is <c>null</c>.</exception>
         public static void UnWatch(Window window)
         {
-            if (window == null)
+            if (window is null)
             {
                 throw new ArgumentNullException(nameof(window));
             }
@@ -127,7 +127,7 @@ namespace Fluence.Wpf
             }
 
             HwndSource source = HwndSource.FromHwnd(handle);
-            if (source == null)
+            if (source is null)
             {
                 return;
             }
@@ -138,7 +138,7 @@ namespace Fluence.Wpf
 
         private static void DetachHook(WatchedWindow watched)
         {
-            if (!watched.IsHooked || watched.HwndSource == null)
+            if (!watched.IsHooked || watched.HwndSource is null)
             {
                 return;
             }
@@ -178,7 +178,7 @@ namespace Fluence.Wpf
 
         private static void OnSystemThemeChanged()
         {
-            if (Application.Current == null)
+            if (Application.Current is null)
             {
                 return;
             }

--- a/docs/superpowers/plans/2026-04-22-mvvm-demo.md
+++ b/docs/superpowers/plans/2026-04-22-mvvm-demo.md
@@ -484,7 +484,7 @@ namespace Fluence.Wpf.Demo.Mvvm.Converters
     {
         /// <inheritdoc />
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
-            value != null && value.Equals(parameter);
+            value is not null && value.Equals(parameter);
 
         /// <inheritdoc />
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>


### PR DESCRIPTION
Because the equality operators can be overloaded, using null pattern checks is better as they truly test for null at an object level.