### PR TITLE
Add `ApplicationThemeManager.ResolvedTheme` auto property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `ApplicationThemeManager.ResolvedTheme` - a new read-only public property that returns the concrete theme (`Light`, `Dark`, or `HighContrast`) resolved and applied during the most recent `Apply` call. When `CurrentTheme` is `Auto`, it reflects the OS theme at the time of the last `Apply` rather than `Auto` itself. Defaults to `Light` before the first `Apply`.
+
 ## [0.8.1-preview] - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- `ApplicationThemeManager.ResolvedTheme` - a new read-only public property that returns the concrete theme (`Light`, `Dark`, or `HighContrast`) resolved and applied during the most recent `Apply` call. When `CurrentTheme` is `Auto`, it reflects the OS theme at the time of the last `Apply` rather than `Auto` itself. Defaults to `Light` before the first `Apply`.
+- `ApplicationThemeManager.ResolvedTheme` - a new read-only public property that returns the concrete theme (`Light`, `Dark`, or `HighContrast`) resolved during the most recent theme pipeline run. The pipeline is triggered by `ApplicationThemeManager.Apply` and also by `ApplicationAccentColorManager.ApplySystemAccent`, `ApplyApplicationAccent`, and `ApplyCustomAccent`, so an accent change alone can update `ResolvedTheme`. When `CurrentTheme` is `Auto`, it reflects the OS theme at the time of the last pipeline run rather than `Auto` itself. Defaults to `Light` before the first pipeline run.
 
 ## [0.8.1-preview] - 2026-06-17
 

--- a/Fluence.Wpf.Tests/ThemeManagerTests.cs
+++ b/Fluence.Wpf.Tests/ThemeManagerTests.cs
@@ -266,5 +266,15 @@ namespace Fluence.Wpf.Tests
             });
         }
 
+        [TestMethod]
+        public void ResolvedTheme_DefaultsToLight_BeforeFirstApply()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                Assert.AreEqual(ApplicationTheme.Light, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must default to Light before the first theme pipeline run.");
+            });
+        }
+
     }
 }

--- a/Fluence.Wpf.Tests/ThemeManagerTests.cs
+++ b/Fluence.Wpf.Tests/ThemeManagerTests.cs
@@ -249,5 +249,22 @@ namespace Fluence.Wpf.Tests
             });
         }
 
+        [TestMethod]
+        public void ResolvedTheme_RemainsConsistentAfterAccentChange()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.Dark, BackdropType.None, updateAccent: false);
+                ApplicationTheme themeBeforeAccent = ApplicationThemeManager.ResolvedTheme;
+
+                ApplicationAccentColorManager.ApplyCustomAccent(System.Windows.Media.Color.FromRgb(0xFF, 0x00, 0x00));
+
+                Assert.AreEqual(themeBeforeAccent, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme should remain the same concrete theme after an accent change via ApplyCustomAccent.");
+                Assert.AreNotEqual(ApplicationTheme.Auto, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must never be Auto after an accent pipeline run.");
+            });
+        }
+
     }
 }

--- a/Fluence.Wpf.Tests/ThemeManagerTests.cs
+++ b/Fluence.Wpf.Tests/ThemeManagerTests.cs
@@ -257,7 +257,7 @@ namespace Fluence.Wpf.Tests
                 ApplicationThemeManager.Apply(ApplicationTheme.Dark, BackdropType.None, updateAccent: false);
                 ApplicationTheme themeBeforeAccent = ApplicationThemeManager.ResolvedTheme;
 
-                ApplicationAccentColorManager.ApplyCustomAccent(System.Windows.Media.Color.FromRgb(0xFF, 0x00, 0x00));
+                ApplicationAccentColorManager.ApplyCustomAccent(Color.FromRgb(0xFF, 0x00, 0x00));
 
                 Assert.AreEqual(themeBeforeAccent, ApplicationThemeManager.ResolvedTheme,
                     "ResolvedTheme should remain the same concrete theme after an accent change via ApplyCustomAccent.");

--- a/Fluence.Wpf.Tests/ThemeManagerTests.cs
+++ b/Fluence.Wpf.Tests/ThemeManagerTests.cs
@@ -175,5 +175,79 @@ namespace Fluence.Wpf.Tests
             Assert.AreEqual(!registryLight, result);
         }
 
+        [TestMethod]
+        public void Apply_Light_ResolvedThemeIsLight()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: false);
+                Assert.AreEqual(ApplicationTheme.Light, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must be Light after Apply(Light).");
+            });
+        }
+
+        [TestMethod]
+        public void Apply_Dark_ResolvedThemeIsDark()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.Dark, BackdropType.None, updateAccent: false);
+                Assert.AreEqual(ApplicationTheme.Dark, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must be Dark after Apply(Dark).");
+            });
+        }
+
+        [TestMethod]
+        public void Apply_HighContrast_ResolvedThemeIsHighContrast()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.HighContrast, BackdropType.None, updateAccent: false);
+                Assert.AreEqual(ApplicationTheme.HighContrast, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must be HighContrast after Apply(HighContrast).");
+            });
+        }
+
+        [TestMethod]
+        public void Apply_ExplicitTheme_ResolvedThemeNeverReturnsAuto()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: false);
+                Assert.AreNotEqual(ApplicationTheme.Auto, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must never be Auto; it must always be a concrete resolved value.");
+            });
+        }
+
+        [TestMethod]
+        public void Apply_Auto_ResolvedThemeIsNotAuto()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.Auto, BackdropType.None, updateAccent: false);
+                Assert.AreNotEqual(ApplicationTheme.Auto, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme must never be Auto; even when CurrentTheme is Auto it must resolve to a concrete value.");
+            });
+        }
+
+        [TestMethod]
+        public void ResolvedTheme_TracksLastAppliedTheme()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: false);
+                Assert.AreEqual(ApplicationTheme.Light, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme should be Light after first Apply(Light).");
+
+                ApplicationThemeManager.Apply(ApplicationTheme.Dark, BackdropType.None, updateAccent: false);
+                Assert.AreEqual(ApplicationTheme.Dark, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme should update to Dark after Apply(Dark).");
+
+                ApplicationThemeManager.Apply(ApplicationTheme.HighContrast, BackdropType.None, updateAccent: false);
+                Assert.AreEqual(ApplicationTheme.HighContrast, ApplicationThemeManager.ResolvedTheme,
+                    "ResolvedTheme should update to HighContrast after Apply(HighContrast).");
+            });
+        }
+
     }
 }

--- a/Fluence.Wpf/ApplicationThemeManager.cs
+++ b/Fluence.Wpf/ApplicationThemeManager.cs
@@ -54,10 +54,14 @@ namespace Fluence.Wpf
 
         /// <summary>
         /// Gets the concrete theme (Light, Dark, or HighContrast) that was resolved and applied during
-        /// the most recent <see cref="Apply"/> call. When <see cref="CurrentTheme"/> is
-        /// <see cref="ApplicationTheme.Auto"/>, this reflects the OS theme at the time of the last
-        /// <c>Apply</c>; it does not update automatically when the OS theme changes without a subsequent
-        /// <c>Apply</c>. Before the first <c>Apply</c> call, this property returns
+        /// the most recent theme pipeline run -- that is, the last call to <see cref="Apply"/> or to any
+        /// <see cref="ApplicationAccentColorManager"/> apply method
+        /// (<see cref="ApplicationAccentColorManager.ApplySystemAccent"/>,
+        /// <see cref="ApplicationAccentColorManager.ApplyApplicationAccent"/>, or
+        /// <see cref="ApplicationAccentColorManager.ApplyCustomAccent"/>), whichever occurred last. When
+        /// <see cref="CurrentTheme"/> is <see cref="ApplicationTheme.Auto"/>, this reflects the OS theme
+        /// at the time of that last pipeline run; it does not update automatically when the OS theme
+        /// changes without a subsequent pipeline run. Before the first pipeline run, this property returns
         /// <see cref="ApplicationTheme.Light"/> as the pre-initialization default.
         /// </summary>
         public static ApplicationTheme ResolvedTheme => FluenceThemeEngine.ResolvedTheme;

--- a/Fluence.Wpf/ApplicationThemeManager.cs
+++ b/Fluence.Wpf/ApplicationThemeManager.cs
@@ -54,11 +54,11 @@ namespace Fluence.Wpf
 
         /// <summary>
         /// Gets the concrete theme (Light, Dark, or HighContrast) that was resolved and applied during
-        /// the most recent theme pipeline run -- that is, the last call to <see cref="Apply"/> or to any
+        /// the most recent theme pipeline run (that is, the last call to <see cref="Apply"/> or to any
         /// <see cref="ApplicationAccentColorManager"/> apply method
         /// (<see cref="ApplicationAccentColorManager.ApplySystemAccent"/>,
         /// <see cref="ApplicationAccentColorManager.ApplyApplicationAccent"/>, or
-        /// <see cref="ApplicationAccentColorManager.ApplyCustomAccent"/>), whichever occurred last. When
+        /// <see cref="ApplicationAccentColorManager.ApplyCustomAccent"/>), whichever ran last. When
         /// <see cref="CurrentTheme"/> is <see cref="ApplicationTheme.Auto"/>, this reflects the OS theme
         /// at the time of that last pipeline run; it does not update automatically when the OS theme
         /// changes without a subsequent pipeline run. Before the first pipeline run, this property returns

--- a/Fluence.Wpf/ApplicationThemeManager.cs
+++ b/Fluence.Wpf/ApplicationThemeManager.cs
@@ -53,7 +53,11 @@ namespace Fluence.Wpf
         public static BackdropType CurrentBackdrop { get; private set; } = BackdropType.Auto;
 
         /// <summary>
-        /// Gets the currently resolved theme after applying the resolution algorithm to <see cref="CurrentTheme"/>.
+        /// Gets the concrete theme (Light, Dark, or HighContrast) that was resolved and applied during
+        /// the most recent <see cref="Apply"/> call. When <see cref="CurrentTheme"/> is
+        /// <see cref="ApplicationTheme.Auto"/>, this reflects the OS theme at the time of the last
+        /// <c>Apply</c>; it does not update automatically when the OS theme changes without a subsequent
+        /// <c>Apply</c>.
         /// </summary>
         public static ApplicationTheme ResolvedTheme => FluenceThemeEngine.ResolvedTheme;
 

--- a/Fluence.Wpf/ApplicationThemeManager.cs
+++ b/Fluence.Wpf/ApplicationThemeManager.cs
@@ -57,7 +57,8 @@ namespace Fluence.Wpf
         /// the most recent <see cref="Apply"/> call. When <see cref="CurrentTheme"/> is
         /// <see cref="ApplicationTheme.Auto"/>, this reflects the OS theme at the time of the last
         /// <c>Apply</c>; it does not update automatically when the OS theme changes without a subsequent
-        /// <c>Apply</c>.
+        /// <c>Apply</c>. Before the first <c>Apply</c> call, this property returns
+        /// <see cref="ApplicationTheme.Light"/> as the pre-initialization default.
         /// </summary>
         public static ApplicationTheme ResolvedTheme => FluenceThemeEngine.ResolvedTheme;
 

--- a/Fluence.Wpf/ApplicationThemeManager.cs
+++ b/Fluence.Wpf/ApplicationThemeManager.cs
@@ -53,6 +53,11 @@ namespace Fluence.Wpf
         public static BackdropType CurrentBackdrop { get; private set; } = BackdropType.Auto;
 
         /// <summary>
+        /// Gets the currently resolved theme after applying the resolution algorithm to <see cref="CurrentTheme"/>.
+        /// </summary>
+        public static ApplicationTheme ResolvedTheme => FluenceThemeEngine.ResolvedTheme;
+
+        /// <summary>
         /// Gets a value indicating whether the Windows system (window-chrome) color mode is currently Dark.
         /// Reflects the live registry value; independent of <see cref="CurrentTheme"/>.
         /// </summary>


### PR DESCRIPTION
﻿## Summary

Does what it says on the tin.

## Verification

- [ ] `dotnet build Fluence.Wpf.sln -c Release --no-restore -v minimal` (0 errors / 0 warnings, both TFMs)
- [ ] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net472 --no-build`
- [ ] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net10.0-windows10.0.26100.0 --no-build`
- [ ] `pwsh eng/Format-Xaml.ps1 -Check` passes (authored XAML conforms to `Settings.XamlStyler`).
- [ ] Visual pass completed in `Fluence.Wpf.Demo` for Light, Dark, High Contrast, accent swap, and relevant backdrop.

## Checklist

- [ ] Public API changes have XML docs and tests; the test count does not drop below the baseline.
- [ ] Template or visual changes use canonical WinUI-style theme keys and `DynamicResource` where theme-bound (no inline hex colors).
- [ ] Visual or behavioral choices are grounded in a Section 4 reference authority (in-tree precedent, WinUI 3 CommonStyles, or .NET 10 WPF Themes).
- [ ] `CHANGELOG.md` is updated under `Unreleased`.
- [ ] Public docs are updated when consumer behavior changes.
- [ ] No unrelated files or local tool state are included.