### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 ﻿name: Build & Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/sintaxasn/Fluence.Wpf/security/code-scanning/1](https://github.com/sintaxasn/Fluence.Wpf/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/build.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the safest minimal fix that preserves current behavior is:

- `contents: read`

This is sufficient for checkout and typical CI read operations. Artifact upload and cache actions do not require broad repository write permissions via `GITHUB_TOKEN`.  
Place the block directly under `name:` (or before `jobs:`) to make it unambiguous and globally applied.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
