### PR TITLE
Crank Roslynator and Meziantou analysers up to the max.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -57,6 +57,7 @@ roslynator_compiler_diagnostic_fixes.enabled = true
 roslynator_refactorings.enabled = true
 
 # Disable Roslynator rules we don't want to deal with.
+dotnet_diagnostic.RCS1111.severity = none
 dotnet_diagnostic.RCS1181.severity = none
 dotnet_diagnostic.RCS1238.severity = none
 
@@ -68,3 +69,767 @@ dotnet_diagnostic.MA0107.severity = none
 dotnet_diagnostic.MA0110.severity = none
 dotnet_diagnostic.MA0177.severity = none
 dotnet_diagnostic.MA0181.severity = none
+
+
+# Manual enablement for a number of Roslynator rules. This is the only way...
+# https://github.com/dotnet/roslynator/issues/832
+
+# Add blank line after embedded statement
+dotnet_diagnostic.rcs0001.severity = error
+
+# Add blank line after #region
+dotnet_diagnostic.rcs0002.severity = error
+
+# Add blank line after using directive list
+dotnet_diagnostic.rcs0003.severity = error
+
+# Add blank line before #endregion
+dotnet_diagnostic.rcs0005.severity = error
+
+# Add blank line before using directive list
+dotnet_diagnostic.rcs0006.severity = error
+
+# Add blank line between accessors
+dotnet_diagnostic.rcs0007.severity = error
+
+# Add blank line between closing brace and next statement
+dotnet_diagnostic.rcs0008.severity = error
+
+# Add blank line between declaration and documentation comment
+dotnet_diagnostic.rcs0009.severity = error
+
+# Add blank line between declarations
+dotnet_diagnostic.rcs0010.severity = error
+
+# Add/remove blank line between single-line accessors
+dotnet_diagnostic.rcs0011.severity = error
+# Options: roslynator_blank_line_between_single_line_accessors
+
+# Add blank line between single-line declarations
+dotnet_diagnostic.rcs0012.severity = error
+
+# Add blank line between single-line declarations of different kind
+dotnet_diagnostic.rcs0013.severity = error
+
+# Add/remove blank line between using directives
+dotnet_diagnostic.rcs0015.severity = error
+# Options: roslynator_blank_line_between_using_directives
+
+# Put attribute list on its own line
+dotnet_diagnostic.rcs0016.severity = error
+
+# Format accessor's braces on a single line or multiple lines
+dotnet_diagnostic.rcs0020.severity = error
+# Options: roslynator_accessor_braces_style
+
+# Format block's braces on a single line or multiple lines
+dotnet_diagnostic.rcs0021.severity = error
+# Options: roslynator_block_braces_style
+
+# Format type declaration's braces
+dotnet_diagnostic.rcs0023.severity = error
+
+# Add new line after switch label
+dotnet_diagnostic.rcs0024.severity = error
+
+# Put full accessor on its own line
+dotnet_diagnostic.rcs0025.severity = error
+
+# Place new line after/before binary operator
+dotnet_diagnostic.rcs0027.severity = error
+# Options: roslynator_binary_operator_new_line
+
+# Place new line after/before '?:' operator
+dotnet_diagnostic.rcs0028.severity = error
+# Options: roslynator_conditional_operator_new_line
+
+# Put constructor initializer on its own line
+dotnet_diagnostic.rcs0029.severity = error
+
+# Put embedded statement on its own line
+dotnet_diagnostic.rcs0030.severity = error
+
+# Put enum member on its own line
+dotnet_diagnostic.rcs0031.severity = error
+
+# Place new line after/before arrow token
+dotnet_diagnostic.rcs0032.severity = error
+# Options: roslynator_arrow_token_new_line
+
+# Put statement on its own line
+dotnet_diagnostic.rcs0033.severity = error
+
+# Put type parameter constraint on its own line
+dotnet_diagnostic.rcs0034.severity = error
+
+# Remove blank line between single-line declarations of same kind
+dotnet_diagnostic.rcs0036.severity = error
+
+# Remove new line before base list
+dotnet_diagnostic.rcs0039.severity = error
+
+# Remove new line between 'if' keyword and 'else' keyword
+dotnet_diagnostic.rcs0041.severity = error
+
+# Put auto-accessors on a single line
+dotnet_diagnostic.rcs0042.severity = error
+
+# Use carriage return + linefeed as new line
+dotnet_diagnostic.rcs0044.severity = error
+
+# Use linefeed as new line
+dotnet_diagnostic.rcs0045.severity = error
+
+# Use spaces instead of tab
+dotnet_diagnostic.rcs0046.severity = error
+
+# Put initializer on a single line
+dotnet_diagnostic.rcs0048.severity = error
+
+# Add blank line after top comment
+dotnet_diagnostic.rcs0049.severity = error
+
+# Add blank line before top declaration
+dotnet_diagnostic.rcs0050.severity = error
+
+# Add/remove new line before 'while' in 'do' statement
+dotnet_diagnostic.rcs0051.severity = error
+# Options: roslynator_new_line_before_while_in_do_statement
+
+# Place new line after/before equals token
+dotnet_diagnostic.rcs0052.severity = error
+# Options: roslynator_equals_token_new_line
+
+# Fix formatting of a list
+dotnet_diagnostic.rcs0053.severity = error
+
+# Fix formatting of a call chain
+dotnet_diagnostic.rcs0054.severity = error
+
+# Fix formatting of a binary expression chain
+dotnet_diagnostic.rcs0055.severity = error
+
+# A line is too long
+dotnet_diagnostic.rcs0056.severity = error
+# Options: roslynator_max_line_length, roslynator_tab_length
+
+# Normalize whitespace at the beginning of a file
+dotnet_diagnostic.rcs0057.severity = error
+
+# Normalize whitespace at the end of a file
+dotnet_diagnostic.rcs0058.severity = error
+# Options: roslynator_new_line_at_end_of_file
+
+# Place new line after/before null-conditional operator
+dotnet_diagnostic.rcs0059.severity = error
+# Options: roslynator_null_conditional_operator_new_line
+
+# Add/remove line after file scoped namespace declaration
+dotnet_diagnostic.rcs0060.severity = error
+# Options: roslynator_blank_line_after_file_scoped_namespace_declaration
+
+# Add/remove blank line between switch sections
+dotnet_diagnostic.rcs0061.severity = error
+# Options: roslynator_blank_line_between_switch_sections
+
+# Put expression body on its own line
+dotnet_diagnostic.rcs0062.severity = error
+# Options: roslynator_arrow_token_new_line
+
+# Remove unnecessary blank line
+dotnet_diagnostic.rcs0063.severity = error
+# Options: roslynator_blank_line_between_closing_brace_and_switch_section
+
+# Add braces (when expression spans over multiple lines)
+dotnet_diagnostic.rcs1001.severity = error
+
+# Add braces to if-else (when expression spans over multiple lines)
+dotnet_diagnostic.rcs1003.severity = error
+
+# Simplify nested using statement
+dotnet_diagnostic.rcs1005.severity = error
+
+# Merge 'else' with nested 'if'
+dotnet_diagnostic.rcs1006.severity = error
+
+# Add braces
+dotnet_diagnostic.rcs1007.severity = error
+
+# Use predefined type
+dotnet_diagnostic.rcs1013.severity = error
+
+# Use explicitly/implicitly typed array
+dotnet_diagnostic.rcs1014.severity = error
+# Options: roslynator_array_creation_type_style, roslynator_use_collection_expression
+
+# Use nameof operator
+dotnet_diagnostic.rcs1015.severity = error
+
+# Use block body or expression body
+dotnet_diagnostic.rcs1016.severity = error
+# Options: roslynator_arrow_token_new_line, roslynator_body_style, roslynator_use_block_body_when_declaration_spans_over_multiple_lines, roslynator_use_block_body_when_expression_spans_over_multiple_lines
+
+# Add/remove accessibility modifiers
+dotnet_diagnostic.rcs1018.severity = error
+# Options: roslynator_accessibility_modifiers
+
+# Simplify Nullable<T> to T?
+dotnet_diagnostic.rcs1020.severity = error
+
+# Convert lambda expression body to expression body
+dotnet_diagnostic.rcs1021.severity = error
+
+# Remove redundant parentheses
+dotnet_diagnostic.rcs1032.severity = error
+
+# Remove redundant boolean literal
+dotnet_diagnostic.rcs1033.severity = error
+
+# Remove redundant 'sealed' modifier
+dotnet_diagnostic.rcs1034.severity = error
+
+# Remove trailing white-space
+dotnet_diagnostic.rcs1037.severity = error
+
+# Remove argument list from attribute
+dotnet_diagnostic.rcs1039.severity = error
+
+# Remove enum default underlying type
+dotnet_diagnostic.rcs1042.severity = error
+
+# Remove 'partial' modifier from type with a single part
+dotnet_diagnostic.rcs1043.severity = error
+
+# Remove original exception from throw statement
+dotnet_diagnostic.rcs1044.severity = error
+
+# Asynchronous method name should end with 'Async'
+dotnet_diagnostic.rcs1046.severity = error
+
+# Non-asynchronous method name should not end with 'Async'
+dotnet_diagnostic.rcs1047.severity = error
+
+# Use lambda expression instead of anonymous method
+dotnet_diagnostic.rcs1048.severity = error
+
+# Simplify boolean comparison
+dotnet_diagnostic.rcs1049.severity = error
+
+# Include/omit parentheses when creating new object
+dotnet_diagnostic.rcs1050.severity = error
+# Options: roslynator_object_creation_parentheses_style
+
+# Add/remove parentheses from condition in conditional operator
+dotnet_diagnostic.rcs1051.severity = error
+# Options: roslynator_conditional_operator_condition_parentheses_style
+
+# Unnecessary semicolon at the end of declaration
+dotnet_diagnostic.rcs1055.severity = error
+
+# Avoid usage of using alias directive
+dotnet_diagnostic.rcs1056.severity = error
+
+# Use compound assignment
+dotnet_diagnostic.rcs1058.severity = error
+
+# Avoid locking on publicly accessible instance
+dotnet_diagnostic.rcs1059.severity = error
+
+# Declare each type in separate file
+dotnet_diagnostic.rcs1060.severity = error
+
+# Merge 'if' with nested 'if'
+dotnet_diagnostic.rcs1061.severity = error
+
+# Simplify logical negation
+dotnet_diagnostic.rcs1068.severity = error
+
+# Remove unnecessary case label
+dotnet_diagnostic.rcs1069.severity = error
+
+# Remove redundant default switch section
+dotnet_diagnostic.rcs1070.severity = error
+
+# Remove redundant base constructor call
+dotnet_diagnostic.rcs1071.severity = error
+
+# Convert 'if' to 'return' statement
+dotnet_diagnostic.rcs1073.severity = error
+
+# Remove redundant constructor
+dotnet_diagnostic.rcs1074.severity = error
+
+# Avoid empty catch clause that catches System.Exception
+dotnet_diagnostic.rcs1075.severity = error
+
+# Optimize LINQ method call
+dotnet_diagnostic.rcs1077.severity = error
+
+# Use "" or 'string.Empty'
+dotnet_diagnostic.rcs1078.severity = error
+# Options: roslynator_empty_string_style
+
+# Throwing of new NotImplementedException
+dotnet_diagnostic.rcs1079.severity = error
+
+# Use 'Count/Length' property instead of 'Any' method
+dotnet_diagnostic.rcs1080.severity = error
+
+# Use coalesce expression instead of conditional expression
+dotnet_diagnostic.rcs1084.severity = error
+
+# Use auto-implemented property
+dotnet_diagnostic.rcs1085.severity = error
+
+# Use --/++ operator instead of assignment
+dotnet_diagnostic.rcs1089.severity = error
+
+# Add/remove 'ConfigureAwait(false)' call
+dotnet_diagnostic.rcs1090.severity = error
+# Options: roslynator_configure_await
+
+# File contains no code
+dotnet_diagnostic.rcs1093.severity = error
+
+# Declare using directive on top level
+dotnet_diagnostic.rcs1094.severity = error
+
+# Use 'HasFlag' method or bitwise operator
+dotnet_diagnostic.rcs1096.severity = error
+# Options: roslynator_enum_has_flag_style
+
+# Remove redundant 'ToString' call
+dotnet_diagnostic.rcs1097.severity = error
+
+# Constant values should be placed on right side of comparisons
+dotnet_diagnostic.rcs1098.severity = error
+
+# Default label should be the last label in a switch section
+dotnet_diagnostic.rcs1099.severity = error
+
+# Make class static
+dotnet_diagnostic.rcs1102.severity = error
+
+# Convert 'if' to assignment
+dotnet_diagnostic.rcs1103.severity = error
+
+# Simplify conditional expression
+dotnet_diagnostic.rcs1104.severity = error
+
+# Unnecessary interpolation
+dotnet_diagnostic.rcs1105.severity = error
+
+# Remove redundant 'ToCharArray' call
+dotnet_diagnostic.rcs1107.severity = error
+
+# Add 'static' modifier to all partial class declarations
+dotnet_diagnostic.rcs1108.severity = error
+
+# Declare type inside namespace
+dotnet_diagnostic.rcs1110.severity = error
+
+# Combine 'Enumerable.Where' method chain
+dotnet_diagnostic.rcs1112.severity = error
+
+# Use 'string.IsNullOrEmpty' method
+dotnet_diagnostic.rcs1113.severity = error
+
+# Remove redundant delegate creation
+dotnet_diagnostic.rcs1114.severity = error
+
+# Mark local variable as const
+dotnet_diagnostic.rcs1118.severity = error
+
+# Add parentheses when necessary
+dotnet_diagnostic.rcs1123.severity = error
+
+# Inline local variable
+dotnet_diagnostic.rcs1124.severity = error
+
+# Add braces to if-else
+dotnet_diagnostic.rcs1126.severity = error
+
+# Use coalesce expression
+dotnet_diagnostic.rcs1128.severity = error
+
+# Remove redundant field initialization
+dotnet_diagnostic.rcs1129.severity = error
+
+# Bitwise operation on enum without Flags attribute
+dotnet_diagnostic.rcs1130.severity = error
+
+# Remove redundant overriding member
+dotnet_diagnostic.rcs1132.severity = error
+
+# Remove redundant Dispose/Close call
+dotnet_diagnostic.rcs1133.severity = error
+
+# Remove redundant statement
+dotnet_diagnostic.rcs1134.severity = error
+
+# Declare enum member with zero value (when enum has FlagsAttribute)
+dotnet_diagnostic.rcs1135.severity = error
+
+# Merge switch sections with equivalent content
+dotnet_diagnostic.rcs1136.severity = error
+
+# Add summary to documentation comment
+dotnet_diagnostic.rcs1138.severity = error
+
+# Add summary element to documentation comment
+dotnet_diagnostic.rcs1139.severity = error
+
+# Add exception to documentation comment
+dotnet_diagnostic.rcs1140.severity = error
+
+# Add 'param' element to documentation comment
+dotnet_diagnostic.rcs1141.severity = error
+
+# Add 'typeparam' element to documentation comment
+dotnet_diagnostic.rcs1142.severity = error
+
+# Simplify coalesce expression
+dotnet_diagnostic.rcs1143.severity = error
+
+# Remove redundant 'as' operator
+dotnet_diagnostic.rcs1145.severity = error
+
+# Use conditional access
+dotnet_diagnostic.rcs1146.severity = error
+
+# Remove redundant cast
+dotnet_diagnostic.rcs1151.severity = error
+
+# Sort enum members
+dotnet_diagnostic.rcs1154.severity = error
+
+# Use StringComparison when comparing strings
+dotnet_diagnostic.rcs1155.severity = error
+
+# Use string.Length instead of comparison with empty string
+dotnet_diagnostic.rcs1156.severity = error
+
+# Composite enum value contains undefined flag
+dotnet_diagnostic.rcs1157.severity = error
+
+# Static member in generic type should use a type parameter
+dotnet_diagnostic.rcs1158.severity = error
+
+# Use EventHandler<T>
+dotnet_diagnostic.rcs1159.severity = error
+
+# Abstract type should not have public constructors
+dotnet_diagnostic.rcs1160.severity = error
+
+# Enum should declare explicit values
+dotnet_diagnostic.rcs1161.severity = error
+
+# Unused parameter
+dotnet_diagnostic.rcs1163.severity = error
+
+# Unused type parameter
+dotnet_diagnostic.rcs1164.severity = error
+
+# Unconstrained type parameter checked for null
+dotnet_diagnostic.rcs1165.severity = error
+
+# Value type object is never equal to null
+dotnet_diagnostic.rcs1166.severity = error
+
+# Parameter name differs from base name
+dotnet_diagnostic.rcs1168.severity = error
+
+# Make field read-only
+dotnet_diagnostic.rcs1169.severity = error
+# Options: roslynator_unity_code_analysis.enabled
+
+# Use read-only auto-implemented property
+dotnet_diagnostic.rcs1170.severity = error
+
+# Simplify lazy initialization
+dotnet_diagnostic.rcs1171.severity = error
+
+# Use 'is' operator instead of 'as' operator
+dotnet_diagnostic.rcs1172.severity = error
+
+# Use coalesce expression instead of 'if'
+dotnet_diagnostic.rcs1173.severity = error
+
+# Remove redundant async/await
+dotnet_diagnostic.rcs1174.severity = error
+
+# Unused 'this' parameter
+dotnet_diagnostic.rcs1175.severity = error
+
+# Unnecessary assignment
+dotnet_diagnostic.rcs1179.severity = error
+
+# Inline lazy initialization
+dotnet_diagnostic.rcs1180.severity = error
+
+# Remove redundant base interface
+dotnet_diagnostic.rcs1182.severity = error
+
+# Use Regex instance instead of static method
+dotnet_diagnostic.rcs1186.severity = error
+
+# Use constant instead of field
+dotnet_diagnostic.rcs1187.severity = error
+
+# Remove redundant auto-property initialization
+dotnet_diagnostic.rcs1188.severity = error
+
+# Add or remove region name
+dotnet_diagnostic.rcs1189.severity = error
+
+# Join string expressions
+dotnet_diagnostic.rcs1190.severity = error
+
+# Declare enum value as combination of names
+dotnet_diagnostic.rcs1191.severity = error
+
+# Unnecessary usage of verbatim string literal
+dotnet_diagnostic.rcs1192.severity = error
+
+# Overriding member should not change 'params' modifier
+dotnet_diagnostic.rcs1193.severity = error
+
+# Implement exception constructors
+dotnet_diagnostic.rcs1194.severity = error
+
+# Use ^ operator
+dotnet_diagnostic.rcs1195.severity = error
+
+# Call extension method as instance method
+dotnet_diagnostic.rcs1196.severity = error
+
+# Optimize StringBuilder.Append/AppendLine call
+dotnet_diagnostic.rcs1197.severity = error
+
+# Unnecessary null check
+dotnet_diagnostic.rcs1199.severity = error
+
+# Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
+dotnet_diagnostic.rcs1200.severity = error
+
+# Use method chaining
+dotnet_diagnostic.rcs1201.severity = error
+
+# Avoid NullReferenceException
+dotnet_diagnostic.rcs1202.severity = error
+
+# Use AttributeUsageAttribute
+dotnet_diagnostic.rcs1203.severity = error
+
+# Use EventArgs.Empty
+dotnet_diagnostic.rcs1204.severity = error
+
+# Order named arguments according to the order of parameters
+dotnet_diagnostic.rcs1205.severity = error
+
+# Use conditional access instead of conditional expression
+dotnet_diagnostic.rcs1206.severity = error
+
+# Use anonymous function or method group
+dotnet_diagnostic.rcs1207.severity = error
+# Options: roslynator_use_anonymous_function_or_method_group
+
+# Order type parameter constraints
+dotnet_diagnostic.rcs1209.severity = error
+
+# Return completed task instead of returning null
+dotnet_diagnostic.rcs1210.severity = error
+
+# Remove unnecessary 'else'
+dotnet_diagnostic.rcs1211.severity = error
+
+# Remove redundant assignment
+dotnet_diagnostic.rcs1212.severity = error
+
+# Remove unused member declaration
+dotnet_diagnostic.rcs1213.severity = error
+# Options: roslynator_unity_code_analysis.enabled
+
+# Unnecessary interpolated string
+dotnet_diagnostic.rcs1214.severity = error
+
+# Expression is always equal to true/false
+dotnet_diagnostic.rcs1215.severity = error
+
+# Unnecessary unsafe context
+dotnet_diagnostic.rcs1216.severity = error
+
+# Convert interpolated string to concatenation
+dotnet_diagnostic.rcs1217.severity = error
+
+# Simplify code branching
+dotnet_diagnostic.rcs1218.severity = error
+
+# Use pattern matching instead of combination of 'is' operator and cast operator
+dotnet_diagnostic.rcs1220.severity = error
+
+# Use pattern matching instead of combination of 'as' operator and null check
+dotnet_diagnostic.rcs1221.severity = error
+
+# Merge preprocessor directives
+dotnet_diagnostic.rcs1222.severity = error
+
+# Make method an extension method
+dotnet_diagnostic.rcs1224.severity = error
+
+# Make class sealed
+dotnet_diagnostic.rcs1225.severity = error
+
+# Add paragraph to documentation comment
+dotnet_diagnostic.rcs1226.severity = error
+
+# Validate arguments correctly
+dotnet_diagnostic.rcs1227.severity = error
+
+# Unused element in a documentation comment
+dotnet_diagnostic.rcs1228.severity = error
+
+# Use async/await when necessary
+dotnet_diagnostic.rcs1229.severity = error
+
+# Unnecessary explicit use of enumerator
+dotnet_diagnostic.rcs1230.severity = error
+
+# Order elements in documentation comment
+dotnet_diagnostic.rcs1232.severity = error
+
+# Use short-circuiting operator
+dotnet_diagnostic.rcs1233.severity = error
+
+# Duplicate enum value
+dotnet_diagnostic.rcs1234.severity = error
+
+# Optimize method call
+dotnet_diagnostic.rcs1235.severity = error
+
+# Use exception filter
+dotnet_diagnostic.rcs1236.severity = error
+
+# Use 'for' statement instead of 'while' statement
+dotnet_diagnostic.rcs1239.severity = error
+
+# Operator is unnecessary
+dotnet_diagnostic.rcs1240.severity = error
+
+# Implement non-generic counterpart
+dotnet_diagnostic.rcs1241.severity = error
+
+# Duplicate word in a comment
+dotnet_diagnostic.rcs1243.severity = error
+
+# Simplify 'default' expression
+dotnet_diagnostic.rcs1244.severity = error
+
+# Use element access
+dotnet_diagnostic.rcs1246.severity = error
+
+# Fix documentation comment tag
+dotnet_diagnostic.rcs1247.severity = error
+
+# Normalize null check
+dotnet_diagnostic.rcs1248.severity = error
+# Options: roslynator_null_check_style
+
+# Unnecessary null-forgiving operator
+dotnet_diagnostic.rcs1249.severity = error
+
+# Use implicit/explicit object creation
+dotnet_diagnostic.rcs1250.severity = error
+# Options: roslynator_object_creation_type_style, roslynator_use_collection_expression, roslynator_use_var_instead_of_implicit_object_creation
+
+# Remove unnecessary braces from record declaration
+dotnet_diagnostic.rcs1251.severity = error
+
+# Normalize usage of infinite loop
+dotnet_diagnostic.rcs1252.severity = error
+# Options: roslynator_infinite_loop_style
+
+# Format documentation comment summary
+dotnet_diagnostic.rcs1253.severity = error
+# Options: roslynator_doc_comment_summary_style
+
+# Normalize format of enum flag value
+dotnet_diagnostic.rcs1254.severity = error
+# Options: roslynator_enum_flag_value_style
+
+# Simplify argument null check
+dotnet_diagnostic.rcs1255.severity = error
+
+# Invalid argument null check
+dotnet_diagnostic.rcs1256.severity = error
+
+# Use enum field explicitly
+dotnet_diagnostic.rcs1257.severity = error
+
+# Unnecessary enum flag
+dotnet_diagnostic.rcs1258.severity = error
+
+# Remove empty syntax
+dotnet_diagnostic.rcs1259.severity = error
+
+# Add/remove trailing comma
+dotnet_diagnostic.rcs1260.severity = error
+# Options: roslynator_trailing_comma_style
+
+# Resource can be disposed asynchronously
+dotnet_diagnostic.rcs1261.severity = error
+
+# Unnecessary raw string literal
+dotnet_diagnostic.rcs1262.severity = error
+
+# Invalid reference in a documentation comment
+dotnet_diagnostic.rcs1263.severity = error
+
+# Use 'var' or explicit type
+dotnet_diagnostic.rcs1264.severity = error
+# Options: roslynator_use_var
+
+# Remove redundant catch block
+dotnet_diagnostic.rcs1265.severity = error
+
+# Use raw string literal
+dotnet_diagnostic.rcs1266.severity = error
+
+# Use string interpolation instead of 'string.Concat'
+dotnet_diagnostic.rcs1267.severity = error
+
+# Simplify numeric comparison
+dotnet_diagnostic.rcs1268.severity = error
+
+# Use pattern matching
+dotnet_diagnostic.rcs9001.severity = error
+
+# Use property SyntaxNode.SpanStart
+dotnet_diagnostic.rcs9002.severity = error
+
+# Unnecessary conditional access
+dotnet_diagnostic.rcs9003.severity = error
+
+# Call 'Any' instead of accessing 'Count'
+dotnet_diagnostic.rcs9004.severity = error
+
+# Unnecessary null check
+dotnet_diagnostic.rcs9005.severity = error
+
+# Use element access
+dotnet_diagnostic.rcs9006.severity = error
+
+# Use return value
+dotnet_diagnostic.rcs9007.severity = error
+
+# Call 'Last' instead of using []
+dotnet_diagnostic.rcs9008.severity = error
+
+# Unknown language name
+dotnet_diagnostic.rcs9009.severity = error
+
+# Specify ExportCodeRefactoringProviderAttribute.Name
+dotnet_diagnostic.rcs9010.severity = error
+
+# Specify ExportCodeFixProviderAttribute.Name
+dotnet_diagnostic.rcs9011.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -63,4 +63,8 @@ dotnet_diagnostic.RCS1238.severity = none
 # Disable Meziantou.Analyzer rules we don't want to deal with.
 dotnet_diagnostic.MA0009.severity = none
 dotnet_diagnostic.MA0051.severity = none
+dotnet_diagnostic.MA0104.severity = none
+dotnet_diagnostic.MA0107.severity = none
 dotnet_diagnostic.MA0110.severity = none
+dotnet_diagnostic.MA0177.severity = none
+dotnet_diagnostic.MA0181.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,6 +83,9 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <MeziantouAnalysisMode>all-errors</MeziantouAnalysisMode>
+  </PropertyGroup>
 
   <!-- Common embedded resource for license -->
   <ItemGroup>

--- a/Fluence.Wpf.Demo.Mvvm/Converters/EnumToBoolConverter.cs
+++ b/Fluence.Wpf.Demo.Mvvm/Converters/EnumToBoolConverter.cs
@@ -44,7 +44,7 @@ namespace Fluence.Wpf.Demo.Mvvm.Converters
         /// <inheritdoc />
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value?.Equals(parameter) == true;
+            return (value?.Equals(parameter)) is true;
         }
 
         /// <inheritdoc />

--- a/Fluence.Wpf.Demo.Mvvm/ViewModels/MainViewModel.cs
+++ b/Fluence.Wpf.Demo.Mvvm/ViewModels/MainViewModel.cs
@@ -93,14 +93,14 @@ namespace Fluence.Wpf.Demo.Mvvm.ViewModels
             get
             {
                 int total = _allTasks.Count; int done = _allTasks.Count(static t => t.IsCompleted);
-                return total == 0 ? "No tasks" : string.Format(CultureInfo.CurrentCulture, "{0} of {1} completed", done, total);
+                return total is 0 ? "No tasks" : string.Format(CultureInfo.CurrentCulture, "{0} of {1} completed", done, total);
             }
         }
 
         /// <summary>
         /// Progress bar value 0-100 based on completion ratio.
         /// </summary>
-        public double ProgressValue => _allTasks.Count != 0
+        public double ProgressValue => _allTasks.Count is not 0
             ? (double)_allTasks.Count(static t => t.IsCompleted) / _allTasks.Count * 100
             : 0;
 

--- a/Fluence.Wpf.Demo/App.xaml.cs
+++ b/Fluence.Wpf.Demo/App.xaml.cs
@@ -139,7 +139,7 @@ namespace Fluence.Wpf.Demo
             ListView list = FindVisualChildByName<ListView>(root, "IconCatalogList") ?? throw new InvalidOperationException("The Icons page did not create IconCatalogList.");
             _ = list.ApplyTemplate();
             list.UpdateLayout();
-            if (list.Items.Count == 0)
+            if (list.Items.Count is 0)
             {
                 throw new InvalidOperationException("The Icons page did not load any icon rows.");
             }

--- a/Fluence.Wpf.Demo/DemoNavigationShellState.cs
+++ b/Fluence.Wpf.Demo/DemoNavigationShellState.cs
@@ -67,14 +67,14 @@ namespace Fluence.Wpf.Demo
 
         internal void SetPaneDisplayMode(NavigationViewPaneDisplayMode mode)
         {
-            if (mode == NavigationViewPaneDisplayMode.Top)
+            if (mode is NavigationViewPaneDisplayMode.Top)
             {
                 SetPaneState(NavigationViewPaneDisplayMode.Top, isPaneOpen: true);
                 RaiseChanged();
                 return;
             }
 
-            if (mode == NavigationViewPaneDisplayMode.Left)
+            if (mode is NavigationViewPaneDisplayMode.Left)
             {
                 SetPaneState(NavigationViewPaneDisplayMode.Left, isPaneOpen: true);
             }
@@ -88,12 +88,12 @@ namespace Fluence.Wpf.Demo
 
         internal void ToggleLeftPane()
         {
-            if (_navigationView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
+            if (_navigationView.PaneDisplayMode is NavigationViewPaneDisplayMode.Top)
             {
                 return;
             }
 
-            if (_navigationView.PaneDisplayMode == NavigationViewPaneDisplayMode.Left)
+            if (_navigationView.PaneDisplayMode is NavigationViewPaneDisplayMode.Left)
             {
                 _navigationView.IsPaneOpen = !_navigationView.IsPaneOpen;
                 RaiseChanged();
@@ -110,7 +110,7 @@ namespace Fluence.Wpf.Demo
                 return;
             }
 
-            if (_navigationView.PaneDisplayMode != NavigationViewPaneDisplayMode.Top)
+            if (_navigationView.PaneDisplayMode is not NavigationViewPaneDisplayMode.Top)
             {
                 if (extendsContentIntoTitleBar)
                 {
@@ -170,7 +170,7 @@ namespace Fluence.Wpf.Demo
                 _titleBar.IsPaneToggleButtonVisible =
                     extendsContentIntoTitleBar &&
                     UserPaneToggleButtonVisible &&
-                    _navigationView.PaneDisplayMode != NavigationViewPaneDisplayMode.Top;
+                    _navigationView.PaneDisplayMode is not NavigationViewPaneDisplayMode.Top;
             }
 
             _lastAppliedExtendedTitleBar = extendsContentIntoTitleBar;
@@ -178,7 +178,7 @@ namespace Fluence.Wpf.Demo
 
         private void SetPaneState(NavigationViewPaneDisplayMode mode, bool isPaneOpen)
         {
-            if (mode == NavigationViewPaneDisplayMode.Left)
+            if (mode is NavigationViewPaneDisplayMode.Left)
             {
                 _navigationView.IsPaneOpen = isPaneOpen;
                 _navigationView.PaneDisplayMode = mode;

--- a/Fluence.Wpf.Demo/Fluence.Wpf.Demo.csproj
+++ b/Fluence.Wpf.Demo/Fluence.Wpf.Demo.csproj
@@ -40,4 +40,8 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100.0'">
+    <NoWarn>$(NoWarn);RCS1255</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/Fluence.Wpf.Demo/Fluence.Wpf.Demo.csproj
+++ b/Fluence.Wpf.Demo/Fluence.Wpf.Demo.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Fluence.Wpf.Demo</AssemblyName>
     <ApplicationIcon>..\assets\Fluence_Icon_Light.ico</ApplicationIcon>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <NoWarn>$(NoWarn);CS1591;IDE0330;VSTHRD001</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;VSTHRD001;MA0045</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluence.Wpf.Demo/MainWindow.xaml.cs
+++ b/Fluence.Wpf.Demo/MainWindow.xaml.cs
@@ -367,14 +367,14 @@ namespace Fluence.Wpf.Demo
 
         private void NavSearchBox_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key != Key.Enter)
+            if (e.Key is not Key.Enter)
             {
                 return;
             }
 
             string query = (NavSearchBox?.Text) ?? string.Empty;
             query = query.Trim();
-            if (query.Length == 0)
+            if (query.Length is 0)
             {
                 return;
             }
@@ -445,7 +445,7 @@ namespace Fluence.Wpf.Demo
             }
 
             string query = (NavSearchBox.Text ?? string.Empty).Trim();
-            if (query.Length == 0)
+            if (query.Length is 0)
             {
                 foreach (object obj in DemoNav.Items)
                 {
@@ -670,7 +670,7 @@ namespace Fluence.Wpf.Demo
 
         private void ShellTitleBar_BackRequested(object sender, EventArgs e)
         {
-            if (DemoNav is null || _navigationBackStack.Count == 0)
+            if (DemoNav is null || _navigationBackStack.Count is 0)
             {
                 UpdateBackNavigationState();
                 return;
@@ -731,8 +731,8 @@ namespace Fluence.Wpf.Demo
                 System.Windows.Controls.TextBlock? titleText = GetTitleBarTemplatePart<System.Windows.Controls.TextBlock>("PART_TitleText");
                 if (titleText is null
                     || NavSearchBox is null
-                    || titleText.Visibility != Visibility.Visible
-                    || NavSearchBox.Visibility != Visibility.Visible
+                    || titleText.Visibility is not Visibility.Visible
+                    || NavSearchBox.Visibility is not Visibility.Visible
                     || !titleText.IsVisible
                     || !NavSearchBox.IsVisible)
                 {
@@ -748,8 +748,7 @@ namespace Fluence.Wpf.Demo
                 // If the app icon itself already overlaps the search box there is no room for the
                 // title at all; clear it and bail early rather than attempting to constrain width.
                 ContentPresenter? titleIcon = GetTitleBarTemplatePart<ContentPresenter>("PART_IconPresenter");
-                if (titleIcon is not null
-                    && titleIcon.Visibility == Visibility.Visible
+                if (titleIcon?.Visibility is Visibility.Visible
                     && titleIcon.IsVisible
                     && TryGetVisualX(titleIcon, this, out double titleIconLeft)
                     && titleIconLeft + titleIcon.ActualWidth > searchLeft - 12.0)

--- a/Fluence.Wpf.Demo/Pages/DemoSampleControl.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/DemoSampleControl.xaml.cs
@@ -371,7 +371,7 @@ namespace Fluence.Wpf.Demo.Pages
             SourceTabControl?.Items.Clear();
 
             UpdateSourceVisibility();
-            if (SourceExpander?.IsExpanded == true)
+            if ((SourceExpander?.IsExpanded) is true)
             {
                 LoadSourceTabs();
             }
@@ -531,13 +531,13 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static void AddFormattedLine(Paragraph paragraph, string line, SourceLanguage language)
         {
-            if (language == SourceLanguage.Xaml)
+            if (language is SourceLanguage.Xaml)
             {
                 AddXamlLine(paragraph, line);
                 return;
             }
 
-            if (language == SourceLanguage.CSharp)
+            if (language is SourceLanguage.CSharp)
             {
                 AddCSharpLine(paragraph, line);
                 return;
@@ -666,7 +666,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static void AddRun(Paragraph paragraph, string text, string resourceKey)
         {
-            if (text.Length == 0)
+            if (text.Length is 0)
             {
                 return;
             }
@@ -679,7 +679,7 @@ namespace Fluence.Wpf.Demo.Pages
         private static bool StartsWith(string text, int index, string value)
         {
             return index + value.Length <= text.Length &&
-                   string.Compare(text, index, value, 0, value.Length, StringComparison.Ordinal) == 0;
+                string.Compare(text, index, value, 0, value.Length, StringComparison.Ordinal) is 0;
         }
 
         private static int FindQuotedTextEnd(string text, int start, char quote)

--- a/Fluence.Wpf.Demo/Pages/GalleryAccessibilityPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryAccessibilityPage.xaml.cs
@@ -668,7 +668,7 @@ namespace Fluence.Wpf.Demo.Pages
                 return;
             }
 
-            RtlDemoCard.FlowDirection = RtlToggle.IsChecked == true
+            RtlDemoCard.FlowDirection = RtlToggle.IsChecked is true
                 ? FlowDirection.RightToLeft
                 : FlowDirection.LeftToRight;
         }

--- a/Fluence.Wpf.Demo/Pages/GalleryButtonsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryButtonsPage.xaml.cs
@@ -509,7 +509,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void WrapToggleButton_CheckedChanged(object sender, RoutedEventArgs e)
         {
-            ToggleButtonStateText.Text = WrapToggleButton.IsChecked == true
+            ToggleButtonStateText.Text = WrapToggleButton.IsChecked is true
                 ? "Wrap text: On"
                 : "Wrap text: Off";
         }

--- a/Fluence.Wpf.Demo/Pages/GalleryColorsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryColorsPage.xaml.cs
@@ -31,10 +31,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
-using FluenceBorder = Fluence.Wpf.Controls.Border;
-using FluenceButton = Fluence.Wpf.Controls.Button;
-using FluenceFontIcon = Fluence.Wpf.Controls.FontIcon;
-using FluenceStackPanel = Fluence.Wpf.Controls.StackPanel;
 
 namespace Fluence.Wpf.Demo.Pages
 {
@@ -223,7 +219,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private UIElement CreateSection(ColorSection section)
         {
-            FluenceStackPanel sectionPanel = new()
+            Controls.StackPanel sectionPanel = new()
             {
                 Margin = new Thickness(0, 20, 0, 0),
                 Orientation = Orientation.Vertical,
@@ -242,7 +238,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private UIElement CreateTextExamples()
         {
-            FluenceStackPanel examples = new()
+            Controls.StackPanel examples = new()
             {
                 Orientation = Orientation.Vertical,
                 Spacing = 20,
@@ -299,7 +295,7 @@ namespace Fluence.Wpf.Demo.Pages
                 new("Inverse text", "Text placed on inverse surfaces.", "TextFillColorInverseBrush"),
             ];
 
-            FluenceBorder panel = new()
+            Controls.Border panel = new()
             {
                 Padding = new Thickness(16),
                 BorderThickness = new Thickness(1),
@@ -308,7 +304,7 @@ namespace Fluence.Wpf.Demo.Pages
             panel.SetResourceReference(Border.BackgroundProperty, "CardBackgroundFillColorDefaultBrush");
             panel.SetResourceReference(Border.BorderBrushProperty, "CardStrokeColorDefaultBrush");
 
-            FluenceStackPanel stack = new()
+            Controls.StackPanel stack = new()
             {
                 Orientation = Orientation.Vertical,
                 Spacing = 12,
@@ -327,7 +323,7 @@ namespace Fluence.Wpf.Demo.Pages
             string exampleBorderKey,
             ColorToken[] tokens)
         {
-            FluenceBorder panel = new()
+            Controls.Border panel = new()
             {
                 Padding = new Thickness(16),
                 BorderThickness = new Thickness(1),
@@ -336,7 +332,7 @@ namespace Fluence.Wpf.Demo.Pages
             panel.SetResourceReference(Border.BackgroundProperty, "CardBackgroundFillColorDefaultBrush");
             panel.SetResourceReference(Border.BorderBrushProperty, "CardStrokeColorDefaultBrush");
 
-            FluenceStackPanel stack = new()
+            Controls.StackPanel stack = new()
             {
                 Orientation = Orientation.Vertical,
                 Spacing = 12,
@@ -357,7 +353,7 @@ namespace Fluence.Wpf.Demo.Pages
             string backgroundKey,
             string borderKey)
         {
-            FluenceBorder preview = new()
+            Controls.Border preview = new()
             {
                 MinHeight = 104,
                 Padding = new Thickness(18),
@@ -382,7 +378,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private UIElement CreateExamplePanel(ColorSection section)
         {
-            FluenceBorder panel = new()
+            Controls.Border panel = new()
             {
                 Margin = new Thickness(0, 36, 0, 8),
                 Padding = new Thickness(12),
@@ -392,7 +388,7 @@ namespace Fluence.Wpf.Demo.Pages
             panel.SetResourceReference(Border.BackgroundProperty, "SolidBackgroundFillColorBaseBrush");
             panel.SetResourceReference(Border.BorderBrushProperty, "CardStrokeColorDefaultBrush");
 
-            FluenceStackPanel stack = new()
+            Controls.StackPanel stack = new()
             {
                 Orientation = Orientation.Vertical,
                 Spacing = 8,
@@ -406,7 +402,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static UIElement CreatePreviewSurface(ColorSection section)
         {
-            FluenceBorder preview = new()
+            Controls.Border preview = new()
             {
                 MinHeight = 92,
                 Padding = new Thickness(16),
@@ -431,7 +427,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private UIElement CreateTokenRows(ColorToken[] tokens)
         {
-            FluenceStackPanel rows = new()
+            Controls.StackPanel rows = new()
             {
                 Orientation = Orientation.Vertical,
                 Spacing = 4,
@@ -451,7 +447,7 @@ namespace Fluence.Wpf.Demo.Pages
                     _ = rowGrid.Children.Add(CreateTokenTile(tokens[start + offset], offset, count));
                 }
 
-                FluenceBorder rowBorder = new()
+                Controls.Border rowBorder = new()
                 {
                     CornerRadius = new CornerRadius(8),
                     Child = rowGrid,
@@ -466,7 +462,7 @@ namespace Fluence.Wpf.Demo.Pages
         private UIElement CreateTokenTile(ColorToken token, int index, int count)
         {
             CornerRadius cornerRadius = GetGroupedTileCornerRadius(index, count);
-            FluenceBorder tile = new()
+            Controls.Border tile = new()
             {
                 MinHeight = 166,
                 Margin = new Thickness(2),
@@ -477,7 +473,7 @@ namespace Fluence.Wpf.Demo.Pages
             tile.SetResourceReference(Border.BackgroundProperty, "CardBackgroundFillColorDefaultBrush");
             tile.SetResourceReference(Border.BorderBrushProperty, "CardStrokeColorDefaultBrush");
 
-            FluenceStackPanel content = new()
+            Controls.StackPanel content = new()
             {
                 Margin = new Thickness(10),
                 Orientation = Orientation.Vertical,
@@ -527,10 +523,10 @@ namespace Fluence.Wpf.Demo.Pages
             Grid.SetColumn(title, 0);
             _ = header.Children.Add(title);
 
-            FluenceButton copyButton = new()
+            Controls.Button copyButton = new()
             {
                 Appearance = ControlAppearance.Subtle,
-                Icon = new FluenceFontIcon { Glyph = "\uE8C8", IconFontSize = 14 },
+                Icon = new Controls.FontIcon { Glyph = "\uE8C8", IconFontSize = 14 },
                 MinHeight = 28,
                 MinWidth = 28,
                 Padding = new Thickness(6, 3, 6, 3),
@@ -581,7 +577,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static void CopyTokenButton_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is FluenceButton { Tag: string resourceKey } && !string.IsNullOrWhiteSpace(resourceKey))
+            if (sender is Controls.Button { Tag: string resourceKey } && !string.IsNullOrWhiteSpace(resourceKey))
             {
                 Clipboard.SetText(resourceKey);
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryDataBindingPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryDataBindingPage.xaml.cs
@@ -441,7 +441,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void NewItemBox_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Enter)
+            if (e.Key is Key.Enter)
             {
                 AddItem_Click(sender, e);
                 e.Handled = true;
@@ -486,9 +486,9 @@ namespace Fluence.Wpf.Demo.Pages
                 return;
             }
 
-            SelectionModeListView.SelectionMode = MultipleModeRadio?.IsChecked == true
+            SelectionModeListView.SelectionMode = (MultipleModeRadio?.IsChecked) is true
                 ? SelectionMode.Multiple
-                : ExtendedModeRadio?.IsChecked == true ? SelectionMode.Extended : SelectionMode.Single;
+                : (ExtendedModeRadio?.IsChecked) is true ? SelectionMode.Extended : SelectionMode.Single;
 
             SelectionModeListView.UnselectAll();
             UpdateSelectionLabel();
@@ -507,13 +507,13 @@ namespace Fluence.Wpf.Demo.Pages
             }
 
             int count = SelectionModeListView.SelectedItems.Count;
-            if (count == 0)
+            if (count is 0)
             {
                 SelectionCountLabel.Text = "Selected: none";
                 return;
             }
 
-            SelectionCountLabel.Text = count == 1
+            SelectionCountLabel.Text = count is 1
                 ? string.Format(CultureInfo.CurrentCulture, "Selected: {0}", (SelectionModeListView.SelectedItem as ListViewItem)?.Content ?? "?")
                 : string.Format(CultureInfo.CurrentCulture, "Selected: {0} items", count);
         }

--- a/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml.cs
@@ -425,7 +425,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void RemoveListItem_Click(object sender, RoutedEventArgs e)
         {
-            if (EmptyStateListView is null || EmptyStateListView.Items.Count == 0)
+            if (EmptyStateListView is null || EmptyStateListView.Items.Count is 0)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryFormsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryFormsPage.xaml.cs
@@ -29,7 +29,6 @@
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
-using FluencePasswordBox = Fluence.Wpf.Controls.PasswordBox;
 
 namespace Fluence.Wpf.Demo.Pages
 {
@@ -326,7 +325,7 @@ namespace Fluence.Wpf.Demo.Pages
         {
             Loaded -= GalleryFormsPage_Loaded;
             DependencyPropertyDescriptor
-                .FromProperty(FluencePasswordBox.PasswordProperty, typeof(FluencePasswordBox))
+                .FromProperty(Controls.PasswordBox.PasswordProperty, typeof(Controls.PasswordBox))
                 .AddValueChanged(SignInPasswordBox, SignInPassword_Changed);
         }
 

--- a/Fluence.Wpf.Demo/Pages/GalleryIconsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryIconsPage.xaml.cs
@@ -384,7 +384,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static void FlushTag(List<string> tags, StringBuilder word)
         {
-            if (word.Length == 0)
+            if (word.Length is 0)
             {
                 return;
             }
@@ -408,7 +408,7 @@ namespace Fluence.Wpf.Demo.Pages
                 string? line;
                 while ((line = reader.ReadLine()) is not null)
                 {
-                    if (line.Length == 0)
+                    if (line.Length is 0)
                     {
                         continue;
                     }
@@ -421,7 +421,7 @@ namespace Fluence.Wpf.Demo.Pages
 
                     string name = parts[0].Trim();
                     string code = parts[1].Trim().ToUpperInvariant();
-                    if (name.Length == 0 || code.Length == 0 || names.ContainsKey(code))
+                    if (name.Length is 0 || code.Length is 0 || names.ContainsKey(code))
                     {
                         continue;
                     }

--- a/Fluence.Wpf.Demo/Pages/GalleryIconsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryIconsPage.xaml.cs
@@ -50,7 +50,7 @@ namespace Fluence.Wpf.Demo.Pages
         private const double TileGapWidth = 12.0;
         private const int DefaultColumns = 4;
 
-        private static readonly System.Threading.Lock IconCatalogLock = new();
+        private static readonly Lock IconCatalogLock = new();
         private static readonly char[] SearchTermSeparators = [' '];
         private static readonly CompareInfo OrdinalIgnoreCaseCompareInfo = CultureInfo.InvariantCulture.CompareInfo;
         private static List<IconCatalogItem>? cachedIcons;

--- a/Fluence.Wpf.Demo/Pages/GalleryIconsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryIconsPage.xaml.cs
@@ -38,7 +38,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Resources;
-using Fluent = Fluence.Wpf.Controls;
 
 namespace Fluence.Wpf.Demo.Pages
 {
@@ -114,7 +113,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static void CopyIconValueButton_Click(object sender, RoutedEventArgs e)
         {
-            string? value = sender is Fluent.Button button ? button.Tag as string : null;
+            string? value = sender is Controls.Button button ? button.Tag as string : null;
             if (string.IsNullOrWhiteSpace(value))
             {
                 return;

--- a/Fluence.Wpf.Demo/Pages/GalleryInputsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryInputsPage.xaml.cs
@@ -351,7 +351,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void DemoAutoSuggestBox_TextChanged(object sender, Fluence.Wpf.AutoSuggestBoxTextChangedEventArgs e)
         {
-            if (e.Reason != Fluence.Wpf.AutoSuggestionBoxTextChangeReason.UserInput)
+            if (e.Reason is not Fluence.Wpf.AutoSuggestionBoxTextChangeReason.UserInput)
             {
                 return;
             }

--- a/Fluence.Wpf.Demo/Pages/GalleryNavigationPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryNavigationPage.xaml.cs
@@ -28,8 +28,6 @@
 
 using System.Windows;
 using System.Windows.Controls;
-using NavigationView = Fluence.Wpf.Controls.NavigationView;
-using NavigationViewItem = Fluence.Wpf.Controls.NavigationViewItem;
 
 namespace Fluence.Wpf.Demo.Pages
 {
@@ -363,10 +361,10 @@ namespace Fluence.Wpf.Demo.Pages
 
         private void NavigationDemo_ItemInvoked(object sender, NavigationViewItemInvokedEventArgs e)
         {
-            SetNavigationDemoContent(sender as NavigationView, e.InvokedItemContainer);
+            SetNavigationDemoContent(sender as Controls.NavigationView, e.InvokedItemContainer);
         }
 
-        private static void SetNavigationDemoContent(NavigationView? nav, NavigationViewItem item)
+        private static void SetNavigationDemoContent(Controls.NavigationView? nav, Controls.NavigationViewItem item)
         {
             if (nav is null || item is null)
             {

--- a/Fluence.Wpf.Demo/Pages/GallerySelectionPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GallerySelectionPage.xaml.cs
@@ -332,7 +332,7 @@ namespace Fluence.Wpf.Demo.Pages
                 return;
             }
 
-            bool isChecked = SelectAllCheckBox.IsChecked == true;
+            bool isChecked = SelectAllCheckBox.IsChecked is true;
             _updatingSelectAll = true;
             OptionOneCheckBox.IsChecked = isChecked;
             OptionTwoCheckBox.IsChecked = isChecked;
@@ -348,9 +348,9 @@ namespace Fluence.Wpf.Demo.Pages
             }
 
             int selectedCount = 0;
-            selectedCount += OptionOneCheckBox.IsChecked == true ? 1 : 0;
-            selectedCount += OptionTwoCheckBox.IsChecked == true ? 1 : 0;
-            selectedCount += OptionThreeCheckBox.IsChecked == true ? 1 : 0;
+            selectedCount += OptionOneCheckBox.IsChecked is true ? 1 : 0;
+            selectedCount += OptionTwoCheckBox.IsChecked is true ? 1 : 0;
+            selectedCount += OptionThreeCheckBox.IsChecked is true ? 1 : 0;
 
             _updatingSelectAll = true;
             SelectAllCheckBox.IsChecked = selectedCount switch

--- a/Fluence.Wpf.Demo/Pages/GallerySettingsPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GallerySettingsPage.xaml.cs
@@ -181,7 +181,7 @@ namespace Fluence.Wpf.Demo.Pages
         private SettingsNavigationOption GetCurrentNavigationOption()
         {
             NavigationViewPaneDisplayMode? mode = _owner?.GetDemoNavigationPaneDisplayMode();
-            bool isPaneOpen = _owner?.IsDemoNavigationPaneOpen() == true;
+            bool isPaneOpen = (_owner?.IsDemoNavigationPaneOpen()) is true;
 
             return mode switch
             {
@@ -257,7 +257,7 @@ namespace Fluence.Wpf.Demo.Pages
                 return;
             }
 
-            if (ThemeWatcherToggle.IsChecked == true)
+            if (ThemeWatcherToggle.IsChecked is true)
             {
                 SystemThemeWatcher.Watch(host);
                 SystemThemeLabel.Text = "Watching: Yes";
@@ -303,11 +303,11 @@ namespace Fluence.Wpf.Demo.Pages
                 return;
             }
 
-            bool showTitle = ShowWindowTitleToggle.IsChecked == true;
+            bool showTitle = ShowWindowTitleToggle.IsChecked is true;
             string title = showTitle ? MainWindow.GalleryWindowTitle : string.Empty;
             _owner.SetUserShowTitle(showTitle, title);
 
-            bool showIcon = ShowWindowIconToggle.IsChecked == true;
+            bool showIcon = ShowWindowIconToggle.IsChecked is true;
             // Use FluenceWindow's rasterized brand icon (the same BitmapSource it applies by default),
             // not the raw vector DrawingImage resource: Window.Icon drives the Win32 HICON, which does
             // not reliably render a DrawingImage, so a re-toggle would otherwise blank the taskbar icon.

--- a/Fluence.Wpf.Demo/Pages/GalleryStatusPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryStatusPage.xaml.cs
@@ -467,7 +467,7 @@ namespace Fluence.Wpf.Demo.Pages
                 return;
             }
 
-            IndeterminateProgressBar.ProgressMode = IndeterminateToggle.IsChecked == true
+            IndeterminateProgressBar.ProgressMode = IndeterminateToggle.IsChecked is true
                 ? ProgressBarMode.Indeterminate
                 : ProgressBarMode.Standard;
         }

--- a/Fluence.Wpf.Demo/Pages/GalleryTypographyPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryTypographyPage.xaml.cs
@@ -72,7 +72,7 @@ namespace Fluence.Wpf.Demo.Pages
             {
                 int rowIndex = i + 1;
                 TypographyTable.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-                AddTypographyRow(rowIndex, Rows[i], i % 2 == 0);
+                AddTypographyRow(rowIndex, Rows[i], i % 2 is 0);
             }
         }
 

--- a/Fluence.Wpf.Demo/Pages/GalleryTypographyPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryTypographyPage.xaml.cs
@@ -31,7 +31,6 @@ using System.Threading;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;
-using Fluent = Fluence.Wpf.Controls;
 
 namespace Fluence.Wpf.Demo.Pages
 {
@@ -118,11 +117,11 @@ namespace Fluence.Wpf.Demo.Pages
             return textBlock;
         }
 
-        private static Fluent.Button CreateCopyButton(string styleKey)
+        private static Controls.Button CreateCopyButton(string styleKey)
         {
-            Fluent.Button button = new()
+            Controls.Button button = new()
             {
-                Content = new Fluent.FontIcon { Glyph = CopyGlyph, IconFontSize = 16 },
+                Content = new Controls.FontIcon { Glyph = CopyGlyph, IconFontSize = 16 },
                 Height = 36,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 Margin = new Thickness(12, 8, 24, 8),
@@ -147,7 +146,7 @@ namespace Fluence.Wpf.Demo.Pages
 
         private static void CopyStyleKey_Click(object sender, RoutedEventArgs e)
         {
-            string? styleKey = sender is Fluent.Button button ? button.Tag as string : null;
+            string? styleKey = sender is Controls.Button button ? button.Tag as string : null;
             if (string.IsNullOrWhiteSpace(styleKey))
             {
                 return;

--- a/Fluence.Wpf.Tests/AccentPaletteRegenerationExperiment.cs
+++ b/Fluence.Wpf.Tests/AccentPaletteRegenerationExperiment.cs
@@ -140,7 +140,7 @@ namespace Fluence.Wpf.Tests
 
                 WriteDword(Registry.CurrentUser, DwmKey, DwmAccentColorValue, dwmEncoded);
 
-                if (writeMode != WriteMode.DwmAccentColorOnly)
+                if (writeMode is not WriteMode.DwmAccentColorOnly)
                 {
                     WriteDword(Registry.CurrentUser, DwmKey, DwmAccentColorInactiveValue, dwmEncoded);
                     WriteDword(Registry.CurrentUser, AccentKey, NativeConstants.AccentColor, explorerEncoded);
@@ -148,7 +148,7 @@ namespace Fluence.Wpf.Tests
                     WriteDword(Registry.CurrentUser, AccentKey, StartColorMenuValue, explorerEncoded);
                 }
 
-                if (writeMode == WriteMode.AllAccentValuesAndBroadcast)
+                if (writeMode is WriteMode.AllAccentValuesAndBroadcast)
                 {
                     _ = NativeMethods.SendMessageTimeout(new IntPtr(NativeMethods.HWND_BROADCAST),
                         NativeConstants.WM_SETTINGCHANGE, IntPtr.Zero, "ImmersiveColorSet",

--- a/Fluence.Wpf.Tests/AdditionalControlsTests.cs
+++ b/Fluence.Wpf.Tests/AdditionalControlsTests.cs
@@ -40,7 +40,7 @@ namespace Fluence.Wpf.Tests
     {
         private static void Drain(Dispatcher d)
         {
-            d.Invoke(static () => { }, DispatcherPriority.ApplicationIdle);
+            d.Invoke(static () => { }, DispatcherPriority.ApplicationIdle, default);
         }
 
         private static Application? EnsureApp()

--- a/Fluence.Wpf.Tests/ComboBoxTests.cs
+++ b/Fluence.Wpf.Tests/ComboBoxTests.cs
@@ -226,7 +226,7 @@ namespace Fluence.Wpf.Tests
                     window.Width = 200;
                     window.Height = 80;
                     window.Show();
-                    WpfTestSta.Dispatcher?.Invoke(static () => { }, System.Windows.Threading.DispatcherPriority.Background);
+                    WpfTestSta.Dispatcher?.Invoke(static () => { }, System.Windows.Threading.DispatcherPriority.Background, default);
                     window.UpdateLayout();
                     _ = comboBox.ApplyTemplate();
 

--- a/Fluence.Wpf.Tests/ControlTests.BackgroundParity.cs
+++ b/Fluence.Wpf.Tests/ControlTests.BackgroundParity.cs
@@ -580,7 +580,7 @@ namespace Fluence.Wpf.Tests
 
         private static bool IsWholeXamlAttribute(string source, int attributeIndex)
         {
-            if (attributeIndex == 0)
+            if (attributeIndex is 0)
             {
                 return true;
             }
@@ -591,7 +591,7 @@ namespace Fluence.Wpf.Tests
 
         private static bool IsLiteralBackgroundValue(string value)
         {
-            if (value.Length == 0)
+            if (value.Length is 0)
             {
                 return false;
             }

--- a/Fluence.Wpf.Tests/ControlTests.BackgroundParity.cs
+++ b/Fluence.Wpf.Tests/ControlTests.BackgroundParity.cs
@@ -35,13 +35,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
-using FluenceCheckBox = Fluence.Wpf.Controls.CheckBox;
-using FluenceExpander = Fluence.Wpf.Controls.Expander;
-using FluenceProgressBar = Fluence.Wpf.Controls.ProgressBar;
-using FluenceRadioButton = Fluence.Wpf.Controls.RadioButton;
-using FluenceToggleSwitch = Fluence.Wpf.Controls.ToggleSwitch;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfEllipse = System.Windows.Shapes.Ellipse;
 
 namespace Fluence.Wpf.Tests
 {
@@ -55,9 +48,9 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 _ = MergeGenericDictionary(application);
 
-                FluenceCheckBox checkBox = new() { Content = "Check" };
-                FluenceRadioButton radioButton = new() { Content = "Radio" };
-                FluenceToggleSwitch toggleSwitch = new() { OffContent = "Off", OnContent = "On" };
+                Controls.CheckBox checkBox = new() { Content = "Check" };
+                Controls.RadioButton radioButton = new() { Content = "Radio" };
+                Controls.ToggleSwitch toggleSwitch = new() { OffContent = "Off", OnContent = "On" };
 
                 StackPanel panel = new();
                 _ = panel.Children.Add(checkBox);
@@ -81,9 +74,9 @@ namespace Fluence.Wpf.Tests
                     _ = radioButton.ApplyTemplate();
                     _ = toggleSwitch.ApplyTemplate();
 
-                    WpfBorder? indicatorFill = FindVisualChildByName<WpfBorder>(checkBox, "IndicatorFill");
-                    WpfBorder? indicatorHover = FindVisualChildByName<WpfBorder>(checkBox, "IndicatorHover");
-                    WpfBorder? indicatorPressed = FindVisualChildByName<WpfBorder>(checkBox, "IndicatorPressed");
+                    Border? indicatorFill = FindVisualChildByName<Border>(checkBox, "IndicatorFill");
+                    Border? indicatorHover = FindVisualChildByName<Border>(checkBox, "IndicatorHover");
+                    Border? indicatorPressed = FindVisualChildByName<Border>(checkBox, "IndicatorPressed");
                     Assert.IsNotNull(indicatorFill, "CheckBox template must expose IndicatorFill.");
                     Assert.IsNotNull(indicatorHover, "CheckBox template must expose IndicatorHover.");
                     Assert.IsNotNull(indicatorPressed, "CheckBox template must expose IndicatorPressed.");
@@ -97,9 +90,9 @@ namespace Fluence.Wpf.Tests
                     AssertBrushColor(indicatorPressed.BorderBrush, "ControlStrongStrokeColorDisabledBrush",
                         "Unchecked CheckBox pressed stroke should use the WinUI pressed stroke token.");
 
-                    WpfEllipse? outerEllipse = FindVisualChildByName<WpfEllipse>(radioButton, "OuterEllipse");
-                    WpfEllipse? outerEllipseHover = FindVisualChildByName<WpfEllipse>(radioButton, "OuterEllipseHover");
-                    WpfEllipse? outerEllipsePressed = FindVisualChildByName<WpfEllipse>(radioButton, "OuterEllipsePressed");
+                    System.Windows.Shapes.Ellipse? outerEllipse = FindVisualChildByName<System.Windows.Shapes.Ellipse>(radioButton, "OuterEllipse");
+                    System.Windows.Shapes.Ellipse? outerEllipseHover = FindVisualChildByName<System.Windows.Shapes.Ellipse>(radioButton, "OuterEllipseHover");
+                    System.Windows.Shapes.Ellipse? outerEllipsePressed = FindVisualChildByName<System.Windows.Shapes.Ellipse>(radioButton, "OuterEllipsePressed");
                     Assert.IsNotNull(outerEllipse, "RadioButton template must expose OuterEllipse.");
                     Assert.IsNotNull(outerEllipseHover, "RadioButton template must expose OuterEllipseHover.");
                     Assert.IsNotNull(outerEllipsePressed, "RadioButton template must expose OuterEllipsePressed.");
@@ -113,9 +106,9 @@ namespace Fluence.Wpf.Tests
                     AssertBrushColor(outerEllipsePressed.Stroke, "ControlStrongStrokeColorDisabledBrush",
                         "Unchecked RadioButton pressed stroke should use the WinUI pressed stroke token.");
 
-                    WpfBorder? trackOff = FindVisualChildByName<WpfBorder>(toggleSwitch, "TrackOff");
-                    WpfBorder? trackOffHover = FindVisualChildByName<WpfBorder>(toggleSwitch, "TrackOffHover");
-                    WpfBorder? trackOffPressed = FindVisualChildByName<WpfBorder>(toggleSwitch, "TrackOffPressed");
+                    Border? trackOff = FindVisualChildByName<Border>(toggleSwitch, "TrackOff");
+                    Border? trackOffHover = FindVisualChildByName<Border>(toggleSwitch, "TrackOffHover");
+                    Border? trackOffPressed = FindVisualChildByName<Border>(toggleSwitch, "TrackOffPressed");
                     Assert.IsNotNull(trackOff, "ToggleSwitch template must expose TrackOff.");
                     Assert.IsNotNull(trackOffHover, "ToggleSwitch template must expose TrackOffHover.");
                     Assert.IsNotNull(trackOffPressed, "ToggleSwitch template must expose TrackOffPressed.");
@@ -144,7 +137,7 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 _ = MergeGenericDictionary(application);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -163,7 +156,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     _ = progressBar.ApplyTemplate();
 
-                    WpfBorder? track = FindVisualChildByName<WpfBorder>(progressBar, "PART_Track");
+                    Border? track = FindVisualChildByName<Border>(progressBar, "PART_Track");
                     Assert.IsNotNull(track, "ProgressBar template must expose PART_Track.");
                     AssertBrushColor(track.Background, "ControlStrongStrokeColorDefaultBrush",
                         "ProgressBar track should use the WinUI ProgressBarBackground role.");
@@ -207,7 +200,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     _ = scrollBar.ApplyTemplate();
 
-                    WpfBorder? trackBackground = FindVisualChildByName<WpfBorder>(scrollBar, "TrackBackground");
+                    Border? trackBackground = FindVisualChildByName<Border>(scrollBar, "TrackBackground");
                     Assert.IsNotNull(trackBackground, "ScrollBar template must expose TrackBackground.");
                     AssertBrushColor(trackBackground.Background, "ScrollBarTrackFillBrush",
                         "ScrollBar rail should use the WinUI ScrollBarTrackFill role.");
@@ -250,16 +243,16 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfBorder? sampleCard = sample.FindName("SampleCard") as WpfBorder;
-                    FluenceExpander? sourceExpander = sample.FindName("SourceExpander") as FluenceExpander;
+                    Border? sampleCard = sample.FindName("SampleCard") as Border;
+                    Controls.Expander? sourceExpander = sample.FindName("SourceExpander") as Controls.Expander;
                     Assert.IsNotNull(sampleCard, "DemoSampleControl must expose SampleCard.");
                     Assert.IsNotNull(sourceExpander, "DemoSampleControl must expose SourceExpander.");
 
                     Assert.AreEqual(new CornerRadius(8, 8, 0, 0), sampleCard.CornerRadius,
                         "Demo sample display should attach to the source section with WinUI Gallery corners.");
                     Grid? demoRegionGrid = sample.FindName("DemoRegionGrid") as Grid;
-                    WpfBorder? rightRail = sample.FindName("RightRailBorder") as WpfBorder;
-                    WpfBorder? outputRegion = sample.FindName("OutputRegion") as WpfBorder;
+                    Border? rightRail = sample.FindName("RightRailBorder") as Border;
+                    Border? outputRegion = sample.FindName("OutputRegion") as Border;
                     Assert.IsNotNull(demoRegionGrid, "DemoSampleControl must expose DemoRegionGrid.");
                     Assert.IsNotNull(rightRail, "DemoSampleControl must expose RightRailBorder.");
                     Assert.IsNotNull(outputRegion, "DemoSampleControl must expose OutputRegion.");
@@ -284,7 +277,7 @@ namespace Fluence.Wpf.Tests
                     window.UpdateLayout();
 
                     RichTextBox? sourceViewer = FindVisualChildByName<RichTextBox>(sourceExpander, "SourceTextViewer");
-                    WpfBorder? copyButtonHost = FindVisualChildByName<WpfBorder>(sourceExpander, "CopySourceButtonHost");
+                    Border? copyButtonHost = FindVisualChildByName<Border>(sourceExpander, "CopySourceButtonHost");
                     Assert.IsNotNull(sourceViewer, "Expanded source should expose the code viewer.");
                     Assert.IsNotNull(copyButtonHost, "Expanded source should expose the overlaid copy-button host.");
                     AssertBrushColor(sourceViewer.Background, "SystemFillColorSolidAttentionBackgroundBrush",

--- a/Fluence.Wpf.Tests/ControlTests.BackgroundParity.cs
+++ b/Fluence.Wpf.Tests/ControlTests.BackgroundParity.cs
@@ -575,7 +575,7 @@ namespace Fluence.Wpf.Tests
 
         private static bool ContainsOrdinal(string source, string value)
         {
-            return source.IndexOf(value, StringComparison.Ordinal) >= 0;
+            return source.Contains(value, StringComparison.Ordinal);
         }
 
         private static bool IsWholeXamlAttribute(string source, int attributeIndex)

--- a/Fluence.Wpf.Tests/ControlTests.Button.cs
+++ b/Fluence.Wpf.Tests/ControlTests.Button.cs
@@ -32,7 +32,6 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using Fluent = Fluence.Wpf.Controls;
 
 namespace Fluence.Wpf.Tests
 {
@@ -92,8 +91,8 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 Window window = new();
-                Fluent.ToolTip toolTip = new() { Content = "Save changes" };
-                Fluent.Button button = new()
+                Controls.ToolTip toolTip = new() { Content = "Save changes" };
+                Controls.Button button = new()
                 {
                     Width = 160,
                     Content = "Save",
@@ -126,11 +125,11 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 Window window = new();
-                Fluent.Button button = new()
+                Controls.Button button = new()
                 {
                     MinWidth = 32,
                     Padding = new Thickness(8, 4, 8, 4),
-                    Icon = new Fluent.FontIcon { Glyph = "", IconFontSize = 14 },
+                    Icon = new Controls.FontIcon { Glyph = "", IconFontSize = 14 },
                 };
 
                 try
@@ -174,9 +173,9 @@ namespace Fluence.Wpf.Tests
                 ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: true);
                 ApplicationAccentColorManager.ApplyCustomAccent(Color.FromRgb(0x00, 0x78, 0xD4));
 
-                Fluent.Button standard = new() { Content = "Standard" };
-                Fluent.Button accent = new() { Appearance = ControlAppearance.Accent, Content = "Accent" };
-                Fluent.Button subtle = new() { Appearance = ControlAppearance.Subtle, Content = "Subtle" };
+                Controls.Button standard = new() { Content = "Standard" };
+                Controls.Button accent = new() { Appearance = ControlAppearance.Accent, Content = "Accent" };
+                Controls.Button subtle = new() { Appearance = ControlAppearance.Subtle, Content = "Subtle" };
                 StackPanel panel = new();
                 _ = panel.Children.Add(standard);
                 _ = panel.Children.Add(accent);
@@ -258,7 +257,7 @@ namespace Fluence.Wpf.Tests
         private static void AssertDisabledAccentButtonUsesDarkTokens()
         {
             Window window = new();
-            Fluent.Button button = new()
+            Controls.Button button = new()
             {
                 Width = 100,
                 Appearance = ControlAppearance.Accent,
@@ -290,7 +289,7 @@ namespace Fluence.Wpf.Tests
         }
 
         private static void AssertButtonChromeMatchesResources(
-            Fluent.Button button,
+            Controls.Button button,
             string backgroundKey,
             string foregroundKey,
             string borderKey)

--- a/Fluence.Wpf.Tests/ControlTests.Button.cs
+++ b/Fluence.Wpf.Tests/ControlTests.Button.cs
@@ -239,7 +239,7 @@ namespace Fluence.Wpf.Tests
             foreach (string resource in requiredStateResources)
             {
                 Assert.IsTrue(
-                    xaml.IndexOf(resource, StringComparison.Ordinal) >= 0,
+                    xaml.Contains(resource, StringComparison.Ordinal),
                     "Button template should include the WinUI state resource: " + resource);
             }
 
@@ -248,10 +248,10 @@ namespace Fluence.Wpf.Tests
                 "<Condition Property=\"IsPressed\" Value=\"True\" />",
                 "<Condition Property=\"Appearance\" Value=\"Accent\" />");
             Assert.IsFalse(
-                accentPressedBlock.IndexOf("AccentFillColorDisabledBrush", StringComparison.Ordinal) >= 0,
+                accentPressedBlock.Contains("AccentFillColorDisabledBrush", StringComparison.Ordinal),
                 "Accent pressed state must not reuse the disabled accent fill as the button Background.");
             Assert.IsFalse(
-                xaml.IndexOf("Value=\"Transparent\"", StringComparison.Ordinal) >= 0,
+                xaml.Contains("Value=\"Transparent\"", StringComparison.Ordinal),
                 "Button template should use theme resources rather than literal transparent brush values.");
         }
 

--- a/Fluence.Wpf.Tests/ControlTests.CaptionButtons.cs
+++ b/Fluence.Wpf.Tests/ControlTests.CaptionButtons.cs
@@ -31,7 +31,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Windows;
 using System.Windows.Threading;
-using WpfButton = System.Windows.Controls.Button;
 
 namespace Fluence.Wpf.Tests
 {
@@ -64,9 +63,9 @@ namespace Fluence.Wpf.Tests
             return window;
         }
 
-        private static WpfButton GetCaptionButton(FluenceWindow window, string name)
+        private static System.Windows.Controls.Button GetCaptionButton(FluenceWindow window, string name)
         {
-            WpfButton? button = FindVisualChildByName<WpfButton>(window, name);
+            System.Windows.Controls.Button? button = FindVisualChildByName<System.Windows.Controls.Button>(window, name);
             Assert.IsNotNull(button,
                 string.Format("Caption template part '{0}' must exist on FluenceWindow.", name));
             return button;
@@ -85,10 +84,10 @@ namespace Fluence.Wpf.Tests
                 {
                     window = CreateAndShowOffScreenFluenceWindow();
 
-                    WpfButton minimize = GetCaptionButton(window, "PART_MinimizeButton");
-                    WpfButton maximize = GetCaptionButton(window, "PART_MaximizeButton");
-                    WpfButton restore = GetCaptionButton(window, "PART_RestoreButton");
-                    WpfButton close = GetCaptionButton(window, "PART_CloseButton");
+                    System.Windows.Controls.Button minimize = GetCaptionButton(window, "PART_MinimizeButton");
+                    System.Windows.Controls.Button maximize = GetCaptionButton(window, "PART_MaximizeButton");
+                    System.Windows.Controls.Button restore = GetCaptionButton(window, "PART_RestoreButton");
+                    System.Windows.Controls.Button close = GetCaptionButton(window, "PART_CloseButton");
 
                     Assert.AreSame(SystemCommands.MinimizeWindowCommand, minimize.Command,
                         "PART_MinimizeButton must bind to SystemCommands.MinimizeWindowCommand.");
@@ -119,10 +118,10 @@ namespace Fluence.Wpf.Tests
                 {
                     window = CreateAndShowOffScreenFluenceWindow();
 
-                    WpfButton minimize = GetCaptionButton(window, "PART_MinimizeButton");
-                    WpfButton maximize = GetCaptionButton(window, "PART_MaximizeButton");
-                    WpfButton restore = GetCaptionButton(window, "PART_RestoreButton");
-                    WpfButton close = GetCaptionButton(window, "PART_CloseButton");
+                    System.Windows.Controls.Button minimize = GetCaptionButton(window, "PART_MinimizeButton");
+                    System.Windows.Controls.Button maximize = GetCaptionButton(window, "PART_MaximizeButton");
+                    System.Windows.Controls.Button restore = GetCaptionButton(window, "PART_RestoreButton");
+                    System.Windows.Controls.Button close = GetCaptionButton(window, "PART_CloseButton");
 
                     Assert.AreEqual(0, System.Windows.Controls.Grid.GetColumn(minimize));
                     Assert.AreEqual(1, System.Windows.Controls.Grid.GetColumn(maximize));

--- a/Fluence.Wpf.Tests/ControlTests.Card.cs
+++ b/Fluence.Wpf.Tests/ControlTests.Card.cs
@@ -30,7 +30,6 @@ using Fluence.Wpf.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
 using System.Windows.Media.Effects;
-using WpfBorder = System.Windows.Controls.Border;
 
 namespace Fluence.Wpf.Tests
 {
@@ -58,7 +57,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? outerBorder = FindVisualChildByName<WpfBorder>(card, "OuterBorder");
+                System.Windows.Controls.Border? outerBorder = FindVisualChildByName<System.Windows.Controls.Border>(card, "OuterBorder");
                 Assert.IsNotNull(outerBorder, "OuterBorder must exist in Card template.");
 
                 Assert.IsNotNull(outerBorder.Effect,
@@ -82,7 +81,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? outerBorder = FindVisualChildByName<WpfBorder>(card, "OuterBorder");
+                System.Windows.Controls.Border? outerBorder = FindVisualChildByName<System.Windows.Controls.Border>(card, "OuterBorder");
                 Assert.IsNotNull(outerBorder, "OuterBorder must exist in Card template.");
 
                 Assert.IsNull(outerBorder.Effect,
@@ -104,7 +103,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? outerBorder = FindVisualChildByName<WpfBorder>(card, "OuterBorder");
+                System.Windows.Controls.Border? outerBorder = FindVisualChildByName<System.Windows.Controls.Border>(card, "OuterBorder");
                 Assert.IsNotNull(outerBorder, "OuterBorder must exist in Card template.");
 
                 Assert.IsNull(outerBorder.Effect,
@@ -126,7 +125,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? outerBorder = FindVisualChildByName<WpfBorder>(card, "OuterBorder");
+                System.Windows.Controls.Border? outerBorder = FindVisualChildByName<System.Windows.Controls.Border>(card, "OuterBorder");
                 Assert.IsNotNull(outerBorder, "OuterBorder must exist in Card template.");
 
                 Assert.IsNull(outerBorder.Effect,
@@ -148,7 +147,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? outerBorder = FindVisualChildByName<WpfBorder>(card, "OuterBorder");
+                System.Windows.Controls.Border? outerBorder = FindVisualChildByName<System.Windows.Controls.Border>(card, "OuterBorder");
                 Assert.IsNotNull(outerBorder, "OuterBorder must exist.");
                 DropShadowEffect? shadow = outerBorder.Effect as DropShadowEffect;
                 Assert.IsNotNull(shadow, "Effect must be DropShadowEffect.");

--- a/Fluence.Wpf.Tests/ControlTests.CardAutomation.cs
+++ b/Fluence.Wpf.Tests/ControlTests.CardAutomation.cs
@@ -425,7 +425,7 @@ namespace Fluence.Wpf.Tests
                         Content = "Enable feature",
                         Description = "Some description.",
                     };
-                    checkBox.Description = null!;
+                    checkBox.Description = null;
 
                     string helpText = AutomationProperties.GetHelpText(checkBox);
                     Assert.IsTrue(
@@ -524,7 +524,7 @@ namespace Fluence.Wpf.Tests
                         Content = "Option A",
                         Description = "Some description.",
                     };
-                    radioButton.Description = null!;
+                    radioButton.Description = null;
 
                     string helpText = AutomationProperties.GetHelpText(radioButton);
                     Assert.IsTrue(

--- a/Fluence.Wpf.Tests/ControlTests.ComboBox.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ComboBox.cs
@@ -31,8 +31,6 @@ using System.Collections;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using FluenceComboBox = Fluence.Wpf.Controls.ComboBox;
-using WpfBorder = System.Windows.Controls.Border;
 
 namespace Fluence.Wpf.Tests
 {
@@ -54,7 +52,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceComboBox cb = new();
+                Controls.ComboBox cb = new();
                 _ = cb.Items.Add("One");
                 Window w = new() { Content = cb, Width = 300, Height = 100 };
                 w.Show();
@@ -81,7 +79,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceComboBox cb = new();
+                Controls.ComboBox cb = new();
                 _ = cb.Items.Add("One");
                 Window w = new() { Content = cb, Width = 300, Height = 100 };
                 w.Show();
@@ -107,7 +105,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceComboBox cb = new();
+                Controls.ComboBox cb = new();
                 _ = cb.Items.Add("Alpha");
                 Window w = new() { Content = cb, Width = 300, Height = 100 };
                 w.Show();
@@ -117,7 +115,7 @@ namespace Fluence.Wpf.Tests
                 Assert.IsTrue(transitioned, "GoToState('Focused') must return true.");
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? accentLine = FindVisualChildByName<WpfBorder>(cb, "FocusAccentLine");
+                Border? accentLine = FindVisualChildByName<Border>(cb, "FocusAccentLine");
                 Assert.IsNotNull(accentLine, "FocusAccentLine border must be present in template.");
                 Assert.AreEqual(Visibility.Collapsed, accentLine.Visibility,
                     "ComboBox should never show a focus underline; dropdown items own the selection indicator.");
@@ -135,7 +133,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceComboBox cb = new();
+                Controls.ComboBox cb = new();
                 _ = cb.Items.Add("Beta");
                 Window w = new() { Content = cb, Width = 300, Height = 100 };
                 w.Show();
@@ -148,7 +146,7 @@ namespace Fluence.Wpf.Tests
                 Assert.IsTrue(transitioned, "GoToState('Unfocused') must return true.");
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? accentLine = FindVisualChildByName<WpfBorder>(cb, "FocusAccentLine");
+                Border? accentLine = FindVisualChildByName<Border>(cb, "FocusAccentLine");
                 Assert.IsNotNull(accentLine, "FocusAccentLine border must be present in template.");
                 Assert.AreEqual(0.0, accentLine.Opacity, 0.01,
                     "FocusAccentLine opacity must be 0.0 in Unfocused state.");
@@ -166,14 +164,14 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceComboBox cb = new();
+                Controls.ComboBox cb = new();
                 _ = cb.Items.Add("Alpha");
                 cb.SelectedIndex = 0;
                 Window w = new() { Content = cb, Width = 300, Height = 100 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? accentLine = FindVisualChildByName<WpfBorder>(cb, "FocusAccentLine");
+                Border? accentLine = FindVisualChildByName<Border>(cb, "FocusAccentLine");
                 Assert.IsNotNull(accentLine, "FocusAccentLine border must be present in template.");
                 Assert.AreEqual(Visibility.Collapsed, accentLine.Visibility,
                     "ComboBox should not expose the focused underline visually.");
@@ -192,7 +190,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceComboBox cb = new();
+                Controls.ComboBox cb = new();
                 _ = cb.Items.Add("Gamma");
                 Window w = new() { Content = cb, Width = 300, Height = 100 };
                 w.Show();
@@ -208,7 +206,7 @@ namespace Fluence.Wpf.Tests
                 Assert.IsTrue(transitioned, "GoToState('Focused') must return true after theme cycle.");
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? accentLine = FindVisualChildByName<WpfBorder>(cb, "FocusAccentLine");
+                Border? accentLine = FindVisualChildByName<Border>(cb, "FocusAccentLine");
                 Assert.IsNotNull(accentLine,
                     "FocusAccentLine must be present after theme cycle.");
                 Assert.AreEqual(Visibility.Collapsed, accentLine.Visibility,

--- a/Fluence.Wpf.Tests/ControlTests.CommandBarFlyout.cs
+++ b/Fluence.Wpf.Tests/ControlTests.CommandBarFlyout.cs
@@ -179,7 +179,7 @@ namespace Fluence.Wpf.Tests
                         Icon = new Controls.FontIcon { Glyph = "\uE74D" },
                         Label = "Delete",
                     });
-                    Assert.IsTrue(WaitUntil(window.Dispatcher, 2000, () => moreButton.Visibility == Visibility.Visible),
+                    Assert.IsTrue(WaitUntil(window.Dispatcher, 2000, () => moreButton.Visibility is Visibility.Visible),
                         "The more button must become visible once SecondaryCommands is non-empty.");
                 }
                 finally

--- a/Fluence.Wpf.Tests/ControlTests.ContentDialog.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ContentDialog.cs
@@ -297,7 +297,7 @@ namespace Fluence.Wpf.Tests
         }
 
         [TestMethod]
-        public async Task ContentDialog_OwnerWindowClose_CompletesPendingTaskWithNone()
+        public async Task ContentDialog_OwnerWindowClose_CompletesPendingTaskWithNoneAsync()
         {
             Task<ContentDialogResult>? dialogTask = null;
             RunOnStaThread(() =>
@@ -390,7 +390,7 @@ namespace Fluence.Wpf.Tests
         }
 
         [TestMethod]
-        public async Task ContentDialog_PrimaryButtonClick_CompletesTaskWithPrimaryAndRemovesOverlay()
+        public async Task ContentDialog_PrimaryButtonClick_CompletesTaskWithPrimaryAndRemovesOverlayAsync()
         {
             Task<ContentDialogResult>? dialogTask = null;
             RunOnStaThread(() =>
@@ -445,7 +445,7 @@ namespace Fluence.Wpf.Tests
         }
 
         [TestMethod]
-        public async Task ContentDialog_CloseButtonClick_CompletesTaskWithNone()
+        public async Task ContentDialog_CloseButtonClick_CompletesTaskWithNoneAsync()
         {
             Task<ContentDialogResult>? dialogTask = null;
             RunOnStaThread(() =>
@@ -493,7 +493,7 @@ namespace Fluence.Wpf.Tests
         }
 
         [TestMethod]
-        public async Task ContentDialog_EscapeKey_CompletesTaskWithNone()
+        public async Task ContentDialog_EscapeKey_CompletesTaskWithNoneAsync()
         {
             Task<ContentDialogResult>? dialogTask = null;
             RunOnStaThread(() =>

--- a/Fluence.Wpf.Tests/ControlTests.ContentDialog.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ContentDialog.cs
@@ -880,7 +880,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
 
                     AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(dialog);
-                    _ = Assert.IsInstanceOfType<Fluence.Wpf.Automation.ContentDialogAutomationPeer>(peer,
+                    _ = Assert.IsInstanceOfType<Automation.ContentDialogAutomationPeer>(peer,
                         "ContentDialog.OnCreateAutomationPeer must return a ContentDialogAutomationPeer.");
                     Assert.AreEqual(AutomationControlType.Window, peer.GetAutomationControlType(),
                         "ContentDialog must report the Window control type so assistive technologies treat it as a modal dialog surface.");

--- a/Fluence.Wpf.Tests/ControlTests.ContentDialog.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ContentDialog.cs
@@ -834,7 +834,7 @@ namespace Fluence.Wpf.Tests
                         "Over a FluenceWindow the dialog overlay must be hosted in PART_DialogOverlayHost so the smoke covers the title bar.");
 
                     dialog.Hide();
-                    bool removed = WaitUntil(window.Dispatcher, 2000, () => host.Children.Count == 0);
+                    bool removed = WaitUntil(window.Dispatcher, 2000, () => host.Children.Count is 0);
                     Assert.IsTrue(removed, "Closing the dialog must remove the overlay from PART_DialogOverlayHost.");
                 }
                 finally

--- a/Fluence.Wpf.Tests/ControlTests.DemoSamplePolish.cs
+++ b/Fluence.Wpf.Tests/ControlTests.DemoSamplePolish.cs
@@ -195,7 +195,7 @@ namespace Fluence.Wpf.Tests
                 Assert.IsTrue(filtered.Count < totalIcons, "Searching for zoom should remove non-matching icons.");
                 foreach (GalleryIconsPage.IconCatalogItem item in filtered)
                 {
-                    Assert.IsTrue(item.Name.IndexOf("zoom", StringComparison.OrdinalIgnoreCase) >= 0,
+                    Assert.IsTrue(item.Name.Contains("zoom", StringComparison.OrdinalIgnoreCase),
                         "Filtered icons should match the search term: " + item.Name);
                 }
 
@@ -662,11 +662,11 @@ namespace Fluence.Wpf.Tests
             {
                 List<string> descriptions = [.. FindVisualChildren<DemoSampleControl>(window).Select(static sample => sample.SampleDescription)];
 
-                Assert.IsTrue(descriptions.Exists(static description => description.IndexOf("Separator", StringComparison.OrdinalIgnoreCase) >= 0),
+                Assert.IsTrue(descriptions.Exists(static description => description.Contains("Separator", StringComparison.OrdinalIgnoreCase)),
                     "Layout page should have a dedicated Separator DemoSampleControl.");
-                Assert.IsTrue(descriptions.Exists(static description => description.IndexOf("DockPanel", StringComparison.OrdinalIgnoreCase) >= 0),
+                Assert.IsTrue(descriptions.Exists(static description => description.Contains("DockPanel", StringComparison.OrdinalIgnoreCase)),
                     "Layout page should have a dedicated DockPanel DemoSampleControl.");
-                Assert.IsTrue(descriptions.Exists(static description => description.IndexOf("Expander", StringComparison.OrdinalIgnoreCase) >= 0),
+                Assert.IsTrue(descriptions.Exists(static description => description.Contains("Expander", StringComparison.OrdinalIgnoreCase)),
                     "Layout page should have a dedicated Expander DemoSampleControl.");
 
                 Controls.Expander? dockPanelExpander = FindVisualChildByName<Controls.Expander>(window, "DockPanelOptionsExpander");

--- a/Fluence.Wpf.Tests/ControlTests.FocusVisual.cs
+++ b/Fluence.Wpf.Tests/ControlTests.FocusVisual.cs
@@ -31,13 +31,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Windows;
 using System.Windows.Input;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfButton = System.Windows.Controls.Button;
-using WpfGrid = System.Windows.Controls.Grid;
-using WpfStackPanel = System.Windows.Controls.StackPanel;
-using WpfTabControl = System.Windows.Controls.TabControl;
-using WpfTabItem = System.Windows.Controls.TabItem;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -192,9 +185,9 @@ namespace Fluence.Wpf.Tests
                 Style? sharedStyle = app?.TryFindResource("DefaultCollectionFocusVisualStyle") as Style;
                 Assert.IsNotNull(sharedStyle, "DefaultCollectionFocusVisualStyle must resolve.");
 
-                WpfTabControl tabControl = new();
-                _ = tabControl.Items.Add(new WpfTabItem { Header = "Text", Content = new WpfTextBlock { Text = "A" } });
-                _ = tabControl.Items.Add(new WpfTabItem { Header = "Fill", Content = new WpfTextBlock { Text = "B" } });
+                System.Windows.Controls.TabControl tabControl = new();
+                _ = tabControl.Items.Add(new System.Windows.Controls.TabItem { Header = "Text", Content = new System.Windows.Controls.TextBlock { Text = "A" } });
+                _ = tabControl.Items.Add(new System.Windows.Controls.TabItem { Header = "Fill", Content = new System.Windows.Controls.TextBlock { Text = "B" } });
                 Window w = new() { Content = tabControl, Width = 360, Height = 180 };
 
                 try
@@ -203,7 +196,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(w.Dispatcher);
                     w.UpdateLayout();
 
-                    WpfTabItem? first = tabControl.ItemContainerGenerator.ContainerFromIndex(0) as WpfTabItem;
+                    System.Windows.Controls.TabItem? first = tabControl.ItemContainerGenerator.ContainerFromIndex(0) as System.Windows.Controls.TabItem;
                     Assert.IsNotNull(first, "The first TabItem container should be generated.");
                     Assert.AreSame(sharedStyle, first.FocusVisualStyle,
                         "TabItem should use WPF keyboard focus cues instead of a pointer-sticky custom focus ring.");
@@ -225,16 +218,16 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                WpfTabControl tabControl = new()
+                System.Windows.Controls.TabControl tabControl = new()
                 {
                     Width = 320,
                     Height = 140,
                 };
-                _ = tabControl.Items.Add(new WpfTabItem { Header = "First", Content = new WpfTextBlock { Text = "One" } });
-                _ = tabControl.Items.Add(new WpfTabItem { Header = "Second", Content = new WpfTextBlock { Text = "Two" } });
+                _ = tabControl.Items.Add(new System.Windows.Controls.TabItem { Header = "First", Content = new System.Windows.Controls.TextBlock { Text = "One" } });
+                _ = tabControl.Items.Add(new System.Windows.Controls.TabItem { Header = "Second", Content = new System.Windows.Controls.TextBlock { Text = "Two" } });
 
-                WpfButton afterButton = new() { Content = "After" };
-                WpfStackPanel root = new();
+                System.Windows.Controls.Button afterButton = new() { Content = "After" };
+                System.Windows.Controls.StackPanel root = new();
                 _ = root.Children.Add(tabControl);
                 _ = root.Children.Add(afterButton);
 
@@ -246,8 +239,8 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfTabItem? first = tabControl.ItemContainerGenerator.ContainerFromIndex(0) as WpfTabItem;
-                    WpfTabItem? second = tabControl.ItemContainerGenerator.ContainerFromIndex(1) as WpfTabItem;
+                    System.Windows.Controls.TabItem? first = tabControl.ItemContainerGenerator.ContainerFromIndex(0) as System.Windows.Controls.TabItem;
+                    System.Windows.Controls.TabItem? second = tabControl.ItemContainerGenerator.ContainerFromIndex(1) as System.Windows.Controls.TabItem;
                     Assert.IsNotNull(first, "The first TabControl header should be generated.");
                     Assert.IsNotNull(second, "The second TabControl header should be generated.");
 
@@ -293,8 +286,8 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                TabViewItem first = new() { Header = "First", Content = new WpfTextBlock { Text = "One" } };
-                TabViewItem second = new() { Header = "Second", Content = new WpfTextBlock { Text = "Two" } };
+                TabViewItem first = new() { Header = "First", Content = new System.Windows.Controls.TextBlock { Text = "One" } };
+                TabViewItem second = new() { Header = "Second", Content = new System.Windows.Controls.TextBlock { Text = "Two" } };
                 TabView tabView = new()
                 {
                     Width = 340,
@@ -304,8 +297,8 @@ namespace Fluence.Wpf.Tests
                 _ = tabView.Items.Add(first);
                 _ = tabView.Items.Add(second);
 
-                WpfButton afterButton = new() { Content = "After" };
-                WpfStackPanel root = new();
+                System.Windows.Controls.Button afterButton = new() { Content = "After" };
+                System.Windows.Controls.StackPanel root = new();
                 _ = root.Children.Add(tabView);
                 _ = root.Children.Add(afterButton);
 
@@ -317,8 +310,8 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfGrid? rootGrid = tabView.Template.FindName("RootGrid", tabView) as WpfGrid;
-                    WpfBorder? contentPanel = tabView.Template.FindName("ContentPanel", tabView) as WpfBorder;
+                    System.Windows.Controls.Grid? rootGrid = tabView.Template.FindName("RootGrid", tabView) as System.Windows.Controls.Grid;
+                    System.Windows.Controls.Border? contentPanel = tabView.Template.FindName("ContentPanel", tabView) as System.Windows.Controls.Border;
                     Assert.IsNotNull(rootGrid, "TabView template should expose RootGrid for keyboard navigation.");
                     Assert.IsNotNull(contentPanel, "TabView template should expose ContentPanel for keyboard navigation.");
                     Assert.AreEqual(KeyboardNavigationMode.Continue, KeyboardNavigation.GetTabNavigation(rootGrid),

--- a/Fluence.Wpf.Tests/ControlTests.IconForeground.cs
+++ b/Fluence.Wpf.Tests/ControlTests.IconForeground.cs
@@ -32,7 +32,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
-using Fluent = Fluence.Wpf.Controls;
 
 namespace Fluence.Wpf.Tests
 {
@@ -52,10 +51,10 @@ namespace Fluence.Wpf.Tests
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 ApplicationAccentColorManager.ApplyCustomAccent(Color.FromRgb(0x00, 0x78, 0xD4));
 
-                Fluent.Button button = new()
+                Controls.Button button = new()
                 {
                     Content = "Send",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                 };
                 Window window = new() { Content = button };
 
@@ -110,11 +109,11 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.Button button = new()
+                Controls.Button button = new()
                 {
                     Appearance = ControlAppearance.Accent,
                     Content = "Send",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724", Foreground = Brushes.Red },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724", Foreground = Brushes.Red },
                 };
                 Window window = new() { Content = button };
 
@@ -149,10 +148,10 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.HyperlinkButton link = new()
+                Controls.HyperlinkButton link = new()
                 {
                     Content = "Learn more",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                 };
                 Window window = new() { Content = link };
 
@@ -194,10 +193,10 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.NavigationViewItem item = new()
+                Controls.NavigationViewItem item = new()
                 {
                     Content = "Home",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                 };
                 Window window = new()
                 {
@@ -245,13 +244,13 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.TabViewItem iconTab = new()
+                Controls.TabViewItem iconTab = new()
                 {
                     Header = "Details",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                 };
-                Fluent.TabView tabView = new();
-                _ = tabView.Items.Add(new Fluent.TabViewItem { Header = "First" });
+                Controls.TabView tabView = new();
+                _ = tabView.Items.Add(new Controls.TabViewItem { Header = "First" });
                 _ = tabView.Items.Add(iconTab);
                 tabView.SelectedIndex = 0;
                 Window window = new()
@@ -299,10 +298,10 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.MenuItem menuItem = new()
+                Controls.MenuItem menuItem = new()
                 {
                     Header = "Open",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                 };
                 Window window = new()
                 {
@@ -345,15 +344,15 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.InfoBar custom = new()
+                Controls.InfoBar custom = new()
                 {
                     Title = "Saved",
                     Message = "All changes were written.",
                     Severity = InfoBarSeverity.Error,
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                     IsOpen = true,
                 };
-                Fluent.InfoBar standard = new()
+                Controls.InfoBar standard = new()
                 {
                     Title = "Failure",
                     Message = "Something broke.",
@@ -413,10 +412,10 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.Card card = new()
+                Controls.Card card = new()
                 {
                     Header = "Storage",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                     Content = "Body",
                 };
                 Window window = new()
@@ -460,9 +459,9 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.ComboBox combo = new()
+                Controls.ComboBox combo = new()
                 {
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                 };
                 _ = combo.Items.Add("First");
                 combo.SelectedIndex = 0;
@@ -507,9 +506,9 @@ namespace Fluence.Wpf.Tests
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
 
-                Fluent.TextBox textBox = new()
+                Controls.TextBox textBox = new()
                 {
-                    Icon = new Fluent.FontIcon { Glyph = "\uE724" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE724" },
                     IconPlacement = ElementPlacement.Left,
                     Text = "Value",
                 };
@@ -556,10 +555,10 @@ namespace Fluence.Wpf.Tests
                 ApplicationAccentColorManager.ApplyCustomAccent(Color.FromRgb(0x00, 0x78, 0xD4));
 
                 // Secondary / overflow style: icon column + label column side by side.
-                Fluent.AppBarButton secondary = new()
+                Controls.AppBarButton secondary = new()
                 {
                     Label = "Share",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE72A" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE72A" },
                     Style = (Style)Application.Current.TryFindResource("CommandBarFlyoutSecondaryAppBarButtonStyle"),
                 };
                 Window secondaryWindow = new()
@@ -603,10 +602,10 @@ namespace Fluence.Wpf.Tests
                 }
 
                 // Compact / primary style (implicit style, no key) with Light->Dark switch.
-                Fluent.AppBarButton compact = new()
+                Controls.AppBarButton compact = new()
                 {
                     Label = "Copy",
-                    Icon = new Fluent.FontIcon { Glyph = "\uE72A" },
+                    Icon = new Controls.FontIcon { Glyph = "\uE72A" },
                 };
                 Window compactWindow = new()
                 {
@@ -658,7 +657,7 @@ namespace Fluence.Wpf.Tests
 
         private static Color GetIconForegroundColor(DependencyObject root)
         {
-            Fluent.FontIcon? icon = FindVisualChildren<Fluent.FontIcon>(root).FirstOrDefault();
+            Controls.FontIcon? icon = FindVisualChildren<Controls.FontIcon>(root).FirstOrDefault();
             Assert.IsNotNull(icon, "A FontIcon icon should be present in the visual tree.");
             SolidColorBrush? brush = icon.Foreground as SolidColorBrush;
             Assert.IsNotNull(brush, "The FontIcon Foreground should be a SolidColorBrush.");

--- a/Fluence.Wpf.Tests/ControlTests.InfoBar.cs
+++ b/Fluence.Wpf.Tests/ControlTests.InfoBar.cs
@@ -31,8 +31,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Media;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -58,7 +56,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? root = FindVisualChildByName<WpfBorder>(bar, "RootBorder");
+                System.Windows.Controls.Border? root = FindVisualChildByName<System.Windows.Controls.Border>(bar, "RootBorder");
                 Assert.IsNotNull(root, "RootBorder must exist in InfoBar template (Fluence style applied).");
                 w.Close();
             });
@@ -104,7 +102,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(bar, "IndicatorBar");
+                System.Windows.Controls.Border? indicator = FindVisualChildByName<System.Windows.Controls.Border>(bar, "IndicatorBar");
                 Assert.IsNotNull(indicator, "IndicatorBar must exist in InfoBar template.");
                 Assert.IsNotNull(indicator.Background, "IndicatorBar background must be set for Informational severity.");
                 w.Close();
@@ -124,9 +122,9 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(bar, "IndicatorBar");
+                System.Windows.Controls.Border? indicator = FindVisualChildByName<System.Windows.Controls.Border>(bar, "IndicatorBar");
                 Assert.IsNotNull(indicator, "IndicatorBar must exist.");
-                WpfTextBlock? defaultIcon = FindVisualChildByName<WpfTextBlock>(bar, "DefaultIcon");
+                System.Windows.Controls.TextBlock? defaultIcon = FindVisualChildByName<System.Windows.Controls.TextBlock>(bar, "DefaultIcon");
                 Assert.IsNotNull(defaultIcon, "DefaultIcon must exist.");
                 SolidColorBrush? initial = indicator.Background as SolidColorBrush;
                 Assert.IsNotNull(initial, "Informational IndicatorBar background should be a SolidColorBrush.");
@@ -165,7 +163,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(bar, "IndicatorBar");
+                System.Windows.Controls.Border? indicator = FindVisualChildByName<System.Windows.Controls.Border>(bar, "IndicatorBar");
                 Assert.IsNotNull(indicator, "IndicatorBar must exist.");
                 Brush brushBefore = indicator.Background;
 
@@ -219,7 +217,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? root = FindVisualChildByName<WpfBorder>(bar, "RootBorder");
+                System.Windows.Controls.Border? root = FindVisualChildByName<System.Windows.Controls.Border>(bar, "RootBorder");
                 Assert.IsNotNull(root, "RootBorder must exist in InfoBar template.");
                 Assert.IsFalse(root.ClipToBounds,
                     "RootBorder should not clip action-button focus visuals or shadow rendering.");

--- a/Fluence.Wpf.Tests/ControlTests.ListBox.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ListBox.cs
@@ -29,9 +29,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
 using System.Windows.Media;
-using FluenceListBox = Fluence.Wpf.Controls.ListBox;
-using FluenceListBoxItem = Fluence.Wpf.Controls.ListBoxItem;
-using WpfBorder = System.Windows.Controls.Border;
 
 namespace Fluence.Wpf.Tests
 {
@@ -51,17 +48,17 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceListBox lb = new();
-                _ = lb.Items.Add(new FluenceListBoxItem { Content = "Item A" });
-                _ = lb.Items.Add(new FluenceListBoxItem { Content = "Item B" });
+                Controls.ListBox lb = new();
+                _ = lb.Items.Add(new Controls.ListBoxItem { Content = "Item A" });
+                _ = lb.Items.Add(new Controls.ListBoxItem { Content = "Item B" });
                 Window w = new() { Content = lb, Width = 300, Height = 200 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                FluenceListBoxItem? item = FindVisualChild<FluenceListBoxItem>(lb);
+                Controls.ListBoxItem? item = FindVisualChild<Controls.ListBoxItem>(lb);
                 Assert.IsNotNull(item, "ListBoxItem must exist in visual tree after Show.");
 
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(item, "SelectionIndicator");
+                System.Windows.Controls.Border? indicator = FindVisualChildByName<System.Windows.Controls.Border>(item, "SelectionIndicator");
                 Assert.IsNotNull(indicator, "SelectionIndicator border must be present in ListBoxItem template.");
 
                 Assert.AreEqual(3.0, indicator.Width, 0.01,
@@ -93,16 +90,16 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceListBox lb = new();
-                _ = lb.Items.Add(new FluenceListBoxItem { Content = "Item A" });
-                _ = lb.Items.Add(new FluenceListBoxItem { Content = "Item B" });
+                Controls.ListBox lb = new();
+                _ = lb.Items.Add(new Controls.ListBoxItem { Content = "Item A" });
+                _ = lb.Items.Add(new Controls.ListBoxItem { Content = "Item B" });
                 Window w = new() { Content = lb, Width = 300, Height = 200 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                FluenceListBoxItem? item = FindVisualChild<FluenceListBoxItem>(lb);
+                Controls.ListBoxItem? item = FindVisualChild<Controls.ListBoxItem>(lb);
                 Assert.IsNotNull(item, "ListBoxItem must exist.");
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(item, "SelectionIndicator");
+                System.Windows.Controls.Border? indicator = FindVisualChildByName<System.Windows.Controls.Border>(item, "SelectionIndicator");
                 Assert.IsNotNull(indicator, "SelectionIndicator must be present.");
                 Assert.AreEqual(0.0, indicator.Opacity, 0.01,
                     "SelectionIndicator must be hidden while the item is unselected.");

--- a/Fluence.Wpf.Tests/ControlTests.ListView.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ListView.cs
@@ -31,8 +31,6 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using FluenceListView = Fluence.Wpf.Controls.ListView;
-using WpfBorder = System.Windows.Controls.Border;
 
 namespace Fluence.Wpf.Tests
 {
@@ -55,7 +53,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceListView lv = new();
+                Controls.ListView lv = new();
                 _ = lv.Items.Add(new ListViewItem { Content = "Item A" });
                 _ = lv.Items.Add(new ListViewItem { Content = "Item B" });
                 Window w = new() { Content = lv, Width = 300, Height = 200 };
@@ -66,7 +64,7 @@ namespace Fluence.Wpf.Tests
                 ListViewItem? item = FindVisualChild<ListViewItem>(lv);
                 Assert.IsNotNull(item, "ListViewItem must exist in visual tree after Show.");
 
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(item, "SelectionIndicator");
+                Border? indicator = FindVisualChildByName<Border>(item, "SelectionIndicator");
                 Assert.IsNotNull(indicator,
                     "SelectionIndicator border must be present in ListViewItem template per WI-3 C20.");
                 w.Close();
@@ -81,7 +79,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceListView lv = new();
+                Controls.ListView lv = new();
                 _ = lv.Items.Add(new ListViewItem { Content = "Item A" });
                 Window w = new() { Content = lv, Width = 300, Height = 200 };
                 w.Show();
@@ -89,7 +87,7 @@ namespace Fluence.Wpf.Tests
 
                 ListViewItem? item = FindVisualChild<ListViewItem>(lv);
                 Assert.IsNotNull(item, "ListViewItem must exist.");
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(item, "SelectionIndicator");
+                Border? indicator = FindVisualChildByName<Border>(item, "SelectionIndicator");
                 Assert.IsNotNull(indicator, "SelectionIndicator must be present.");
 
                 Assert.AreEqual(3.0, indicator.Width, 0.01,
@@ -106,7 +104,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceListView lv = new();
+                Controls.ListView lv = new();
                 _ = lv.Items.Add(new ListViewItem { Content = "Item A" });
                 Window w = new() { Content = lv, Width = 300, Height = 200 };
                 w.Show();
@@ -114,7 +112,7 @@ namespace Fluence.Wpf.Tests
 
                 ListViewItem? item = FindVisualChild<ListViewItem>(lv);
                 Assert.IsNotNull(item, "ListViewItem must exist.");
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(item, "SelectionIndicator");
+                Border? indicator = FindVisualChildByName<Border>(item, "SelectionIndicator");
                 Assert.IsNotNull(indicator, "SelectionIndicator must be present.");
 
                 Assert.AreEqual(new CornerRadius(1.5), indicator.CornerRadius,
@@ -131,7 +129,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceListView lv = new();
+                Controls.ListView lv = new();
                 _ = lv.Items.Add(new ListViewItem { Content = "Item A" });
                 Window w = new() { Content = lv, Width = 300, Height = 200 };
                 w.Show();
@@ -139,7 +137,7 @@ namespace Fluence.Wpf.Tests
 
                 ListViewItem? item = FindVisualChild<ListViewItem>(lv);
                 Assert.IsNotNull(item, "ListViewItem must exist.");
-                WpfBorder? indicator = FindVisualChildByName<WpfBorder>(item, "SelectionIndicator");
+                Border? indicator = FindVisualChildByName<Border>(item, "SelectionIndicator");
                 Assert.IsNotNull(indicator, "SelectionIndicator must be present.");
 
                 SolidColorBrush? expected = app?.TryFindResource("AccentFillColorDefaultBrush") as SolidColorBrush;
@@ -164,7 +162,7 @@ namespace Fluence.Wpf.Tests
                 _ = MergeGenericDictionary(app);
 
                 ObservableCollection<string> items = ["One", "Two", "Three"];
-                FluenceListView lv = new()
+                Controls.ListView lv = new()
                 {
                     Width = 300,
                     Height = 180,

--- a/Fluence.Wpf.Tests/ControlTests.NavigationView.cs
+++ b/Fluence.Wpf.Tests/ControlTests.NavigationView.cs
@@ -332,7 +332,7 @@ namespace Fluence.Wpf.Tests
 
                     nav.IsPaneOpen = true;
                     // Settle until the footer host reaches the asserted Visible state.
-                    _ = WaitUntil(window.Dispatcher, 2000, () => footerHost.Visibility == Visibility.Visible);
+                    _ = WaitUntil(window.Dispatcher, 2000, () => footerHost.Visibility is Visibility.Visible);
 
                     Assert.AreEqual(Visibility.Visible, footerHost.Visibility,
                         "LeftCompact footer should be visible when the pane opens.");
@@ -2682,7 +2682,7 @@ topMode: false,
                 return;
             }
 
-            if (brush is SolidColorBrush solid && solid.Color.A == 0)
+            if (brush is SolidColorBrush solid && solid.Color.A is 0)
             {
                 return;
             }

--- a/Fluence.Wpf.Tests/ControlTests.NavigationViewTopParity.cs
+++ b/Fluence.Wpf.Tests/ControlTests.NavigationViewTopParity.cs
@@ -275,7 +275,7 @@ namespace Fluence.Wpf.Tests
                     double visibleItemsRight = double.MinValue;
                     foreach (object item in nav.Items)
                     {
-                        if (item is NavigationViewItem navItem && navItem.Visibility == Visibility.Visible)
+                        if (item is NavigationViewItem navItem && navItem.Visibility is Visibility.Visible)
                         {
                             double itemRight = GetNavigationElementRight(navItem, nav);
                             if (itemRight > visibleItemsRight)
@@ -435,7 +435,7 @@ namespace Fluence.Wpf.Tests
                     double overflowLeft = GetNavigationElementX(overflowButton, nav);
                     foreach (object item in nav.Items)
                     {
-                        if (item is NavigationViewItem navItem && navItem.Visibility == Visibility.Visible)
+                        if (item is NavigationViewItem navItem && navItem.Visibility is Visibility.Visible)
                         {
                             Assert.IsTrue(GetNavigationElementRight(navItem, nav) <= overflowLeft - 4.0 + 1.5,
                                 "Visible top items must clear the overflow button. item=" + navItem.Content);

--- a/Fluence.Wpf.Tests/ControlTests.NavigationViewTopParity.cs
+++ b/Fluence.Wpf.Tests/ControlTests.NavigationViewTopParity.cs
@@ -31,10 +31,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
-using FluentButton = Fluence.Wpf.Controls.Button;
-using FluentMenuItem = Fluence.Wpf.Controls.MenuItem;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfStackPanel = System.Windows.Controls.StackPanel;
 
 namespace Fluence.Wpf.Tests
 {
@@ -190,7 +186,7 @@ namespace Fluence.Wpf.Tests
                         "Top navigation item icon presenter should keep the tighter strip while adding 2px more lead-in before the icon.");
                     Assert.AreEqual(new Thickness(2, 0, 2, 0), contentPresenter.Margin,
                         "Top navigation item text presenter should use 2px horizontal spacing.");
-                    WpfBorder? outerBorder = FindVisualChildByName<WpfBorder>(item, "OuterBorder");
+                    System.Windows.Controls.Border? outerBorder = FindVisualChildByName<System.Windows.Controls.Border>(item, "OuterBorder");
                     ContentPresenter? infoBadgePresenter = FindVisualChildByName<ContentPresenter>(item, "InfoBadgePresenter");
                     Assert.IsNotNull(outerBorder, "Top navigation item template should expose the outer border.");
                     Assert.IsNotNull(infoBadgePresenter, "Navigation item template should expose the info badge presenter.");
@@ -247,7 +243,7 @@ namespace Fluence.Wpf.Tests
                         Width = 300,
                         Height = 320,
                         PaneDisplayMode = NavigationViewPaneDisplayMode.Top,
-                        PaneFooter = new WpfStackPanel { Width = 88, Height = 36 },
+                        PaneFooter = new System.Windows.Controls.StackPanel { Width = 88, Height = 36 },
                     };
                     NavigationViewItem first = new() { Content = "Home", Icon = new FontIcon { Glyph = "\uE80F" } };
                     NavigationViewItem last = new() { Content = "Diagnostics", Icon = new FontIcon { Glyph = "\uE8A7", IconFontSize = 20 } };
@@ -264,7 +260,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    FluentButton? overflowButton = FindVisualChildByName<FluentButton>(nav, "PART_TopOverflowButton");
+                    Controls.Button? overflowButton = FindVisualChildByName<Controls.Button>(nav, "PART_TopOverflowButton");
                     Assert.IsNotNull(overflowButton, "Top pane should expose a three-dot overflow button.");
                     Assert.AreEqual(ControlAppearance.Subtle, overflowButton.Appearance,
                         "Top pane overflow button should use the same subtle Fluence button chrome as other navigation strip buttons.");
@@ -288,7 +284,7 @@ namespace Fluence.Wpf.Tests
                     double overflowButtonGap = GetNavigationElementX(overflowButton, nav) - visibleItemsRight;
                     Assert.AreEqual(4.0, overflowButtonGap, 1.5,
                         "Top pane overflow button should sit after the last visible navigation item using the same 4px strip spacing.");
-                    WpfStackPanel? footer = nav.PaneFooter as WpfStackPanel;
+                    System.Windows.Controls.StackPanel? footer = nav.PaneFooter as System.Windows.Controls.StackPanel;
                     Assert.IsNotNull(footer, "Test setup should use a right-docked PaneFooter.");
                     Assert.IsTrue(GetNavigationElementRight(overflowButton, nav) <= GetNavigationElementX(footer, nav) + 0.5,
                         "Top pane overflow button should appear before the right-docked PaneFooter instead of docking to the strip edge.");
@@ -296,7 +292,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsTrue(overflowButton.ContextMenu.Items.Count > 0,
                         "Top pane overflow menu should contain hidden navigation items.");
 
-                    FluentMenuItem? overflowItem = overflowButton.ContextMenu.Items[^1] as FluentMenuItem;
+                    Controls.MenuItem? overflowItem = overflowButton.ContextMenu.Items[^1] as Controls.MenuItem;
                     Assert.IsNotNull(overflowItem, "Overflow entries should be lightweight Fluence MenuItem rows.");
                     Assert.AreEqual(280.0, overflowItem.MinWidth, 0.01,
                         "Overflow entries should use the wider WinUI-style flyout row width.");
@@ -358,7 +354,7 @@ namespace Fluence.Wpf.Tests
                     window.UpdateLayout();
                     DrainDispatcher(window.Dispatcher);
 
-                    FluentButton? overflowButton = FindVisualChildByName<FluentButton>(nav, "PART_TopOverflowButton");
+                    Controls.Button? overflowButton = FindVisualChildByName<Controls.Button>(nav, "PART_TopOverflowButton");
                     Assert.IsNotNull(overflowButton, "Top pane should expose a three-dot overflow button.");
                     Assert.AreEqual(Visibility.Visible, overflowButton.Visibility,
                         "The overflow button should be visible when all items fit only if the button is not reserved.");
@@ -378,7 +374,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsNotNull(overflowButton.ContextMenu, "Top pane overflow button should own a menu for collapsed items.");
                     Assert.AreEqual(1, overflowButton.ContextMenu.Items.Count,
                         "Measured clearance should move only the trailing item that does not fit to the overflow menu.");
-                    FluentMenuItem? firstOverflowItem = overflowButton.ContextMenu.Items[0] as FluentMenuItem;
+                    Controls.MenuItem? firstOverflowItem = overflowButton.ContextMenu.Items[0] as Controls.MenuItem;
                     Assert.AreEqual("Three", firstOverflowItem?.Header,
                         "The moved item should appear in the overflow menu.");
                 }
@@ -423,7 +419,7 @@ namespace Fluence.Wpf.Tests
                     window.UpdateLayout();
                     DrainDispatcher(window.Dispatcher);
 
-                    FluentButton? overflowButton = FindVisualChildByName<FluentButton>(nav, "PART_TopOverflowButton");
+                    Controls.Button? overflowButton = FindVisualChildByName<Controls.Button>(nav, "PART_TopOverflowButton");
                     Grid? topItemsHost = FindVisualChildByName<Grid>(nav, NavigationView.PartTopItemsHost);
                     Assert.IsNotNull(overflowButton, "Top pane should expose a three-dot overflow button.");
                     Assert.IsNotNull(topItemsHost, "Top pane should expose the horizontal item host.");

--- a/Fluence.Wpf.Tests/ControlTests.NumberBox.cs
+++ b/Fluence.Wpf.Tests/ControlTests.NumberBox.cs
@@ -35,7 +35,6 @@ using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using Fluent = Fluence.Wpf.Controls;
 
 namespace Fluence.Wpf.Tests
 {
@@ -52,7 +51,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         Value = 5,
                         SmallChange = 1,
@@ -105,7 +104,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         Value = 5,
                         SmallChange = 1,
@@ -159,7 +158,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         Value = 0,
                         SpinButtonPlacementMode = SpinButtonPlacementMode.Inline,
@@ -205,7 +204,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         SpinButtonPlacementMode = SpinButtonPlacementMode.Inline,
                         Width = 160,
@@ -253,7 +252,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         SpinButtonPlacementMode = SpinButtonPlacementMode.Inline,
                         Width = 160,
@@ -300,7 +299,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         SpinButtonPlacementMode = SpinButtonPlacementMode.Compact,
                         Width = 180,
@@ -356,7 +355,7 @@ namespace Fluence.Wpf.Tests
         {
             RunOnStaThread(static () =>
             {
-                Fluent.NumberBox numberBox = new()
+                Controls.NumberBox numberBox = new()
                 {
                     Minimum = 0,
                     Maximum = 5,
@@ -373,7 +372,7 @@ namespace Fluence.Wpf.Tests
         {
             RunOnStaThread(static () =>
             {
-                Fluent.NumberBox numberBox = new()
+                Controls.NumberBox numberBox = new()
                 {
                     Minimum = 10,
                     Maximum = 0,
@@ -396,7 +395,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         Minimum = 0,
                         Maximum = 5,
@@ -446,7 +445,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new() { Header = "Quantity" };
+                    Controls.NumberBox numberBox = new() { Header = "Quantity" };
                     window.Content = numberBox;
                     window.Width = 240;
                     window.Height = 120;
@@ -486,7 +485,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.NumberBox numberBox = new()
+                    Controls.NumberBox numberBox = new()
                     {
                         SmallChange = 1,
                         LargeChange = 10,

--- a/Fluence.Wpf.Tests/ControlTests.PasswordBox.cs
+++ b/Fluence.Wpf.Tests/ControlTests.PasswordBox.cs
@@ -33,7 +33,6 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Fluent = Fluence.Wpf.Controls;
 
 namespace Fluence.Wpf.Tests
 {
@@ -50,7 +49,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.PasswordBox box = new()
+                    Controls.PasswordBox box = new()
                     {
                         Password = "secret",
                         Width = 200,
@@ -93,7 +92,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.PasswordBox box = new()
+                    Controls.PasswordBox box = new()
                     {
                         Password = "secret",
                         RevealButtonEnabled = true,
@@ -159,7 +158,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    Fluent.PasswordBox box = new()
+                    Controls.PasswordBox box = new()
                     {
                         Password = "secret",
                         RevealButtonEnabled = true,

--- a/Fluence.Wpf.Tests/ControlTests.PersonPicture.cs
+++ b/Fluence.Wpf.Tests/ControlTests.PersonPicture.cs
@@ -33,9 +33,6 @@ using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Shapes;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfGrid = System.Windows.Controls.Grid;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -82,13 +79,13 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? initialsText = FindVisualChildByName<WpfTextBlock>(pp, "PART_InitialsText");
+                System.Windows.Controls.TextBlock? initialsText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_InitialsText");
                 Assert.IsNotNull(initialsText, "PART_InitialsText must be present.");
 
                 Ellipse? imageEllipse = FindVisualChildByName<Ellipse>(pp, "PART_ImageEllipse");
                 Assert.IsNotNull(imageEllipse, "PART_ImageEllipse must be present.");
 
-                WpfGrid? badgeGrid = FindVisualChildByName<WpfGrid>(pp, "PART_BadgeGrid");
+                System.Windows.Controls.Grid? badgeGrid = FindVisualChildByName<System.Windows.Controls.Grid>(pp, "PART_BadgeGrid");
                 Assert.IsNotNull(badgeGrid, "PART_BadgeGrid must be present.");
 
                 w.Close();
@@ -109,7 +106,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? initialsText = FindVisualChildByName<WpfTextBlock>(pp, "PART_InitialsText");
+                System.Windows.Controls.TextBlock? initialsText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_InitialsText");
                 Assert.IsNotNull(initialsText);
                 // Contact glyph U+E77B
                 Assert.AreEqual("\uE77B", initialsText.Text,
@@ -133,7 +130,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? initialsText = FindVisualChildByName<WpfTextBlock>(pp, "PART_InitialsText");
+                System.Windows.Controls.TextBlock? initialsText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_InitialsText");
                 Assert.IsNotNull(initialsText);
                 Assert.AreEqual("JD", initialsText.Text,
                     "DisplayName='John Doe' must generate initials 'JD'.");
@@ -154,7 +151,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? initialsText = FindVisualChildByName<WpfTextBlock>(pp, "PART_InitialsText");
+                System.Windows.Controls.TextBlock? initialsText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_InitialsText");
                 Assert.IsNotNull(initialsText);
                 Assert.AreEqual("XY", initialsText.Text,
                     "Explicit Initials='XY' must override DisplayName-derived initials.");
@@ -175,7 +172,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? initialsText = FindVisualChildByName<WpfTextBlock>(pp, "PART_InitialsText");
+                System.Windows.Controls.TextBlock? initialsText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_InitialsText");
                 Assert.IsNotNull(initialsText);
                 Assert.AreEqual("\uE716", initialsText.Text,
                     "IsGroup=true must show people glyph U+E716 per WinUI 3 PersonPicture.");
@@ -196,12 +193,12 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfGrid? badgeGrid = FindVisualChildByName<WpfGrid>(pp, "PART_BadgeGrid");
+                System.Windows.Controls.Grid? badgeGrid = FindVisualChildByName<System.Windows.Controls.Grid>(pp, "PART_BadgeGrid");
                 Assert.IsNotNull(badgeGrid);
                 Assert.AreEqual(Visibility.Visible, badgeGrid.Visibility,
                     "BadgeNumber > 0 must make PART_BadgeGrid Visible.");
 
-                WpfTextBlock? badgeText = FindVisualChildByName<WpfTextBlock>(pp, "PART_BadgeText");
+                System.Windows.Controls.TextBlock? badgeText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_BadgeText");
                 Assert.IsNotNull(badgeText);
                 Assert.AreEqual("3", badgeText.Text,
                     "PART_BadgeText must display the BadgeNumber.");
@@ -224,9 +221,9 @@ namespace Fluence.Wpf.Tests
                 w.UpdateLayout();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfGrid? badgeGrid = FindVisualChildByName<WpfGrid>(pp, "PART_BadgeGrid");
-                WpfBorder? badgeBackground = FindVisualChildByName<WpfBorder>(pp, "PART_BadgeBackground");
-                WpfTextBlock? badgeText = FindVisualChildByName<WpfTextBlock>(pp, "PART_BadgeText");
+                System.Windows.Controls.Grid? badgeGrid = FindVisualChildByName<System.Windows.Controls.Grid>(pp, "PART_BadgeGrid");
+                System.Windows.Controls.Border? badgeBackground = FindVisualChildByName<System.Windows.Controls.Border>(pp, "PART_BadgeBackground");
+                System.Windows.Controls.TextBlock? badgeText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_BadgeText");
                 Assert.IsNotNull(badgeGrid);
                 Assert.IsNotNull(badgeBackground);
                 Assert.IsNotNull(badgeText);
@@ -264,7 +261,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfGrid? badgeGrid = FindVisualChildByName<WpfGrid>(pp, "PART_BadgeGrid");
+                System.Windows.Controls.Grid? badgeGrid = FindVisualChildByName<System.Windows.Controls.Grid>(pp, "PART_BadgeGrid");
                 Assert.IsNotNull(badgeGrid);
                 Assert.AreEqual(Visibility.Collapsed, badgeGrid.Visibility,
                     "PART_BadgeGrid must be Collapsed when BadgeNumber=0 and BadgeGlyph=null.");
@@ -309,7 +306,7 @@ namespace Fluence.Wpf.Tests
                 ThemeTestHelpers.ApplyStandardThemeCycle();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? initialsText = FindVisualChildByName<WpfTextBlock>(pp, "PART_InitialsText");
+                System.Windows.Controls.TextBlock? initialsText = FindVisualChildByName<System.Windows.Controls.TextBlock>(pp, "PART_InitialsText");
                 Assert.IsNotNull(initialsText,
                     "PART_InitialsText must still be present after theme cycle.");
                 w.Close();

--- a/Fluence.Wpf.Tests/ControlTests.PipsPager.cs
+++ b/Fluence.Wpf.Tests/ControlTests.PipsPager.cs
@@ -33,11 +33,6 @@ using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Input;
-using WpfButton = System.Windows.Controls.Button;
-using WpfButtonBase = System.Windows.Controls.Primitives.ButtonBase;
-using WpfOrientation = System.Windows.Controls.Orientation;
-using WpfStackPanel = System.Windows.Controls.StackPanel;
-using WpfToggleButton = System.Windows.Controls.Primitives.ToggleButton;
 
 namespace Fluence.Wpf.Tests
 {
@@ -46,10 +41,10 @@ namespace Fluence.Wpf.Tests
     /// </summary>
     public partial class ControlTests
     {
-        private static WpfToggleButton? GetPipAt(WpfStackPanel host, int offset)
+        private static System.Windows.Controls.Primitives.ToggleButton? GetPipAt(System.Windows.Controls.StackPanel host, int offset)
         {
             return offset >= 0 && offset < host.Children.Count
-                ? host.Children[offset] as WpfToggleButton
+                ? host.Children[offset] as System.Windows.Controls.Primitives.ToggleButton
                 : null;
         }
 
@@ -77,16 +72,16 @@ namespace Fluence.Wpf.Tests
                     Assert.AreEqual(0, pager.NumberOfPages, "NumberOfPages must default to 0.");
                     Assert.AreEqual(0, pager.SelectedPageIndex, "SelectedPageIndex must default to 0.");
                     Assert.AreEqual(5, pager.MaxVisiblePips, "MaxVisiblePips must default to 5, matching WinUI.");
-                    Assert.AreEqual(WpfOrientation.Horizontal, pager.Orientation,
+                    Assert.AreEqual(System.Windows.Controls.Orientation.Horizontal, pager.Orientation,
                         "Orientation must default to Horizontal.");
                     Assert.AreEqual(PipsPagerButtonVisibility.Collapsed, pager.PreviousButtonVisibility,
                         "PreviousButtonVisibility must default to Collapsed, matching WinUI.");
                     Assert.AreEqual(PipsPagerButtonVisibility.Collapsed, pager.NextButtonVisibility,
                         "NextButtonVisibility must default to Collapsed, matching WinUI.");
 
-                    WpfButton? previous = FindVisualChildByName<WpfButton>(pager, "PART_PreviousButton");
-                    WpfButton? next = FindVisualChildByName<WpfButton>(pager, "PART_NextButton");
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.Button? previous = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_PreviousButton");
+                    System.Windows.Controls.Button? next = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_NextButton");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(previous, "PART_PreviousButton must be present in the PipsPager template.");
                     Assert.IsNotNull(next, "PART_NextButton must be present in the PipsPager template.");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
@@ -117,13 +112,13 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
                     Assert.AreEqual(5, host.Children.Count, "NumberOfPages=5 must render five pips.");
 
                     for (int offset = 0; offset < 5; offset++)
                     {
-                        WpfToggleButton? pip = GetPipAt(host, offset);
+                        System.Windows.Controls.Primitives.ToggleButton? pip = GetPipAt(host, offset);
                         Assert.IsNotNull(pip,
                             string.Format(CultureInfo.InvariantCulture, "The pip at offset {0} must be a ToggleButton.", offset));
                         Assert.AreEqual(offset is 0, pip.IsChecked,
@@ -169,13 +164,13 @@ namespace Fluence.Wpf.Tests
                         raiseCount++;
                     };
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
 
-                    WpfToggleButton? pip = GetPipAt(host, 3);
+                    System.Windows.Controls.Primitives.ToggleButton? pip = GetPipAt(host, 3);
                     Assert.IsNotNull(pip, "The pip at offset 3 must be a ToggleButton.");
 
-                    pip.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, pip));
+                    pip.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, pip));
                     Assert.AreEqual(3, pager.SelectedPageIndex, "Clicking pip 3 must select page index 3.");
                     Assert.AreEqual(1, raiseCount, "Clicking a pip must raise SelectedIndexChanged once.");
                     Assert.AreEqual(0, oldIndex, "SelectedIndexChanged must carry the previous index.");
@@ -187,7 +182,7 @@ namespace Fluence.Wpf.Tests
                         "The previously selected pip must uncheck.");
 
                     // Re-clicking the selected pip must not move the selection or re-raise.
-                    pip.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, pip));
+                    pip.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, pip));
                     Assert.AreEqual(3, pager.SelectedPageIndex,
                         "Re-clicking the selected pip must keep its page selected.");
                     Assert.AreEqual(1, raiseCount,
@@ -225,32 +220,32 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfButton? previous = FindVisualChildByName<WpfButton>(pager, "PART_PreviousButton");
-                    WpfButton? next = FindVisualChildByName<WpfButton>(pager, "PART_NextButton");
+                    System.Windows.Controls.Button? previous = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_PreviousButton");
+                    System.Windows.Controls.Button? next = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_NextButton");
                     Assert.IsNotNull(previous, "PART_PreviousButton must be present in the PipsPager template.");
                     Assert.IsNotNull(next, "PART_NextButton must be present in the PipsPager template.");
 
                     Assert.IsFalse(previous.IsEnabled, "The previous button must be disabled at the first page.");
                     Assert.IsTrue(next.IsEnabled, "The next button must be enabled while pages remain ahead.");
 
-                    next.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, next));
+                    next.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, next));
                     Assert.AreEqual(1, pager.SelectedPageIndex, "Clicking next must advance the selection.");
                     Assert.IsTrue(previous.IsEnabled, "The previous button must enable once off the first page.");
 
-                    next.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, next));
+                    next.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, next));
                     Assert.AreEqual(2, pager.SelectedPageIndex, "Clicking next again must reach the last page.");
                     Assert.IsFalse(next.IsEnabled, "The next button must be disabled at the last page.");
 
                     // Raising Click bypasses IsEnabled, so this also proves the coercion clamp.
-                    next.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, next));
+                    next.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, next));
                     Assert.AreEqual(2, pager.SelectedPageIndex,
                         "Advancing past the last page must clamp the selection.");
 
-                    previous.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, previous));
+                    previous.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, previous));
                     Assert.AreEqual(1, pager.SelectedPageIndex, "Clicking previous must step the selection back.");
 
-                    previous.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, previous));
-                    previous.RaiseEvent(new RoutedEventArgs(WpfButtonBase.ClickEvent, previous));
+                    previous.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, previous));
+                    previous.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent, previous));
                     Assert.AreEqual(0, pager.SelectedPageIndex,
                         "Stepping back past the first page must clamp the selection.");
                     Assert.IsFalse(previous.IsEnabled,
@@ -281,7 +276,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
 
                     // Selection at the leading edge: the window clamps to the first pages.
@@ -386,25 +381,25 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Controls.FontIcon? previousGlyph = FindVisualChildByName<Controls.FontIcon>(pager, "PreviousGlyph");
                     Controls.FontIcon? nextGlyph = FindVisualChildByName<Controls.FontIcon>(pager, "NextGlyph");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
                     Assert.IsNotNull(previousGlyph, "The previous chevron FontIcon must be present.");
                     Assert.IsNotNull(nextGlyph, "The next chevron FontIcon must be present.");
 
-                    Assert.AreEqual(WpfOrientation.Horizontal, host.Orientation,
+                    Assert.AreEqual(System.Windows.Controls.Orientation.Horizontal, host.Orientation,
                         "The default pager must stack its pips horizontally.");
                     Assert.AreEqual("\uE76B", previousGlyph.Glyph,
                         "The horizontal previous chevron must be ChevronLeft (E76B).");
                     Assert.AreEqual("\uE76C", nextGlyph.Glyph,
                         "The horizontal next chevron must be ChevronRight (E76C).");
 
-                    pager.Orientation = WpfOrientation.Vertical;
+                    pager.Orientation = System.Windows.Controls.Orientation.Vertical;
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    Assert.AreEqual(WpfOrientation.Vertical, host.Orientation,
+                    Assert.AreEqual(System.Windows.Controls.Orientation.Vertical, host.Orientation,
                         "A vertical pager must stack its pips vertically.");
                     Assert.AreEqual("\uE70E", previousGlyph.Glyph,
                         "The vertical previous chevron must be ChevronUp (E70E).");
@@ -436,8 +431,8 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfButton? previous = FindVisualChildByName<WpfButton>(pager, "PART_PreviousButton");
-                    WpfButton? next = FindVisualChildByName<WpfButton>(pager, "PART_NextButton");
+                    System.Windows.Controls.Button? previous = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_PreviousButton");
+                    System.Windows.Controls.Button? next = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_NextButton");
                     Assert.IsNotNull(previous, "PART_PreviousButton must be present in the PipsPager template.");
                     Assert.IsNotNull(next, "PART_NextButton must be present in the PipsPager template.");
 
@@ -490,10 +485,10 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
 
-                    WpfToggleButton? pip = GetPipAt(host, 0);
+                    System.Windows.Controls.Primitives.ToggleButton? pip = GetPipAt(host, 0);
                     Assert.IsNotNull(pip, "The pip at offset 0 must be a ToggleButton.");
                     _ = pip.Focus();
 
@@ -586,7 +581,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
 
                     object? strongFill = app?.TryFindResource("ControlStrongFillColorDefaultBrush");
@@ -597,7 +592,7 @@ namespace Fluence.Wpf.Tests
                     // neutral strong fill as the pips when not hovered or pressed. The next button
                     // is enabled at the first page, so its Foreground reflects the rest setter
                     // (the previous button is disabled at page 0 and shows the disabled brush).
-                    WpfButton? nextButton = FindVisualChildByName<WpfButton>(pager, "PART_NextButton");
+                    System.Windows.Controls.Button? nextButton = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_NextButton");
                     Assert.IsNotNull(nextButton, "PART_NextButton must be present in the PipsPager template.");
                     Assert.IsTrue(nextButton.IsEnabled, "The next button must be enabled at the first page.");
                     Assert.AreSame(strongFill, nextButton.Foreground,
@@ -609,14 +604,14 @@ namespace Fluence.Wpf.Tests
                     // disabled setter.
                     object? strongFillDisabled = app?.TryFindResource("ControlStrongFillColorDisabledBrush");
                     Assert.IsNotNull(strongFillDisabled, "ControlStrongFillColorDisabledBrush must resolve.");
-                    WpfButton? previousButton = FindVisualChildByName<WpfButton>(pager, "PART_PreviousButton");
+                    System.Windows.Controls.Button? previousButton = FindVisualChildByName<System.Windows.Controls.Button>(pager, "PART_PreviousButton");
                     Assert.IsNotNull(previousButton, "PART_PreviousButton must be present in the PipsPager template.");
                     Assert.IsFalse(previousButton.IsEnabled, "The previous button must be disabled at the first page.");
                     Assert.AreSame(strongFillDisabled, previousButton.Foreground,
                         "The disabled navigation button Foreground must be ControlStrongFillColorDisabledBrush.");
 
-                    WpfToggleButton? selectedPip = GetPipAt(host, 0);
-                    WpfToggleButton? restPip = GetPipAt(host, 1);
+                    System.Windows.Controls.Primitives.ToggleButton? selectedPip = GetPipAt(host, 0);
+                    System.Windows.Controls.Primitives.ToggleButton? restPip = GetPipAt(host, 1);
                     Assert.IsNotNull(selectedPip, "The selected pip must be a ToggleButton.");
                     Assert.IsNotNull(restPip, "The rest pip must be a ToggleButton.");
 
@@ -671,12 +666,12 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfStackPanel? host = FindVisualChildByName<WpfStackPanel>(pager, "PART_PipsHost");
+                    System.Windows.Controls.StackPanel? host = FindVisualChildByName<System.Windows.Controls.StackPanel>(pager, "PART_PipsHost");
                     Assert.IsNotNull(host, "PART_PipsHost must be present in the PipsPager template.");
 
-                    static System.Windows.Shapes.Ellipse? DotAt(WpfStackPanel pipsHost, int offset)
+                    static System.Windows.Shapes.Ellipse? DotAt(System.Windows.Controls.StackPanel pipsHost, int offset)
                     {
-                        WpfToggleButton? pip = GetPipAt(pipsHost, offset);
+                        System.Windows.Controls.Primitives.ToggleButton? pip = GetPipAt(pipsHost, offset);
                         return pip is null
                             ? null
                             : FindVisualChildByName<System.Windows.Shapes.Ellipse>(pip, "Pip");

--- a/Fluence.Wpf.Tests/ControlTests.PipsPager.cs
+++ b/Fluence.Wpf.Tests/ControlTests.PipsPager.cs
@@ -126,7 +126,7 @@ namespace Fluence.Wpf.Tests
                         WpfToggleButton? pip = GetPipAt(host, offset);
                         Assert.IsNotNull(pip,
                             string.Format(CultureInfo.InvariantCulture, "The pip at offset {0} must be a ToggleButton.", offset));
-                        Assert.AreEqual(offset == 0, pip.IsChecked,
+                        Assert.AreEqual(offset is 0, pip.IsChecked,
                             string.Format(CultureInfo.InvariantCulture, "Only the selected (first) pip must be checked; offset {0}.", offset));
                         Assert.AreEqual(
                             string.Format(CultureInfo.InvariantCulture, "Page {0}", offset + 1),

--- a/Fluence.Wpf.Tests/ControlTests.ProgressBar.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ProgressBar.cs
@@ -31,10 +31,6 @@ using System;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Media;
-using FluenceProgressBar = Fluence.Wpf.Controls.ProgressBar;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfContentControl = System.Windows.Controls.ContentControl;
-using WpfGrid = System.Windows.Controls.Grid;
 
 namespace Fluence.Wpf.Tests
 {
@@ -55,7 +51,7 @@ namespace Fluence.Wpf.Tests
                 _ = MergeGenericDictionary(app);
                 ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: true);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -66,7 +62,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? fill = FindVisualChildByName<WpfBorder>(progressBar, "PART_Fill");
+                System.Windows.Controls.Border? fill = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Fill");
                 Assert.IsNotNull(fill, "ProgressBar template must expose PART_Fill.");
                 SolidColorBrush? initial = fill.Background as SolidColorBrush;
                 Assert.IsNotNull(initial, "PART_Fill.Background should be a SolidColorBrush.");
@@ -104,7 +100,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -114,7 +110,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? track = FindVisualChildByName<WpfBorder>(progressBar, "PART_Track");
+                System.Windows.Controls.Border? track = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Track");
                 Assert.IsNotNull(track, "ProgressBar template must expose PART_Track.");
 
                 Assert.AreEqual(1.0, progressBar.TrackHeight, 0.1,
@@ -138,7 +134,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -149,7 +145,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? fill = FindVisualChildByName<WpfBorder>(progressBar, "PART_Fill");
+                System.Windows.Controls.Border? fill = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Fill");
                 Assert.IsNotNull(fill, "ProgressBar template must expose PART_Fill.");
 
                 progressBar.ProgressMode = ProgressBarMode.Standard;
@@ -174,7 +170,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -184,7 +180,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfGrid? host = FindVisualChildByName<WpfGrid>(progressBar, "ProgressBarIndicatorHost");
+                System.Windows.Controls.Grid? host = FindVisualChildByName<System.Windows.Controls.Grid>(progressBar, "ProgressBarIndicatorHost");
                 Assert.IsNotNull(host, "ProgressBar template must expose the ProgressBarIndicatorHost panel.");
 
                 // ClipToBounds only clips rectangularly, so the translating indeterminate bars would
@@ -211,7 +207,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -221,9 +217,9 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? track = FindVisualChildByName<WpfBorder>(progressBar, "PART_Track");
-                WpfBorder? bar1 = FindVisualChildByName<WpfBorder>(progressBar, "PART_IndeterminateBar");
-                WpfBorder? bar2 = FindVisualChildByName<WpfBorder>(progressBar, "PART_IndeterminateBar2");
+                System.Windows.Controls.Border? track = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Track");
+                System.Windows.Controls.Border? bar1 = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_IndeterminateBar");
+                System.Windows.Controls.Border? bar2 = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_IndeterminateBar2");
                 Assert.IsNotNull(track, "ProgressBar template must expose PART_Track.");
                 Assert.IsNotNull(bar1, "ProgressBar template must expose PART_IndeterminateBar.");
                 Assert.IsNotNull(bar2, "ProgressBar template must expose PART_IndeterminateBar2.");
@@ -247,7 +243,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -257,10 +253,10 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? track = FindVisualChildByName<WpfBorder>(progressBar, "PART_Track");
-                WpfBorder? fill = FindVisualChildByName<WpfBorder>(progressBar, "PART_Fill");
-                WpfBorder? bar1 = FindVisualChildByName<WpfBorder>(progressBar, "PART_IndeterminateBar");
-                WpfBorder? bar2 = FindVisualChildByName<WpfBorder>(progressBar, "PART_IndeterminateBar2");
+                System.Windows.Controls.Border? track = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Track");
+                System.Windows.Controls.Border? fill = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Fill");
+                System.Windows.Controls.Border? bar1 = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_IndeterminateBar");
+                System.Windows.Controls.Border? bar2 = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_IndeterminateBar2");
                 Assert.IsNotNull(track, "ProgressBar template must expose PART_Track.");
                 Assert.IsNotNull(fill, "ProgressBar template must expose PART_Fill.");
                 Assert.IsNotNull(bar1, "ProgressBar template must expose PART_IndeterminateBar.");
@@ -312,13 +308,13 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
                     IsIndeterminate = true,
                 };
-                WpfContentControl host = new() { Content = progressBar };
+                System.Windows.Controls.ContentControl host = new() { Content = progressBar };
                 Window w = new() { Content = host, Width = 300, Height = 120 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -364,7 +360,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     ProgressMode = ProgressBarMode.Indeterminate,
                 };
@@ -377,14 +373,14 @@ namespace Fluence.Wpf.Tests
             });
         }
 
-        private static void AssertProgressBarStatePrimitiveBrush(Action<FluenceProgressBar> applyState, string brushKey)
+        private static void AssertProgressBarStatePrimitiveBrush(Action<Controls.ProgressBar> applyState, string brushKey)
         {
             WpfTestSta.Invoke(() =>
             {
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -397,7 +393,7 @@ namespace Fluence.Wpf.Tests
                 applyState(progressBar);
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? fill = FindVisualChildByName<WpfBorder>(progressBar, "PART_Fill");
+                System.Windows.Controls.Border? fill = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Fill");
                 Assert.IsNotNull(fill, "ProgressBar template must expose PART_Fill.");
 
                 SolidColorBrush? expected = app?.TryFindResource(brushKey) as SolidColorBrush;
@@ -419,7 +415,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new() { Value = 50, Width = 240, Height = 24 };
+                Controls.ProgressBar progressBar = new() { Value = 50, Width = 240, Height = 24 };
                 Window window = new() { Content = progressBar };
                 window.Show();
                 _ = progressBar.ApplyTemplate();
@@ -438,7 +434,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceProgressBar progressBar = new()
+                Controls.ProgressBar progressBar = new()
                 {
                     Width = 240,
                     Height = 24,
@@ -449,7 +445,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? fill = FindVisualChildByName<WpfBorder>(progressBar, "PART_Fill");
+                System.Windows.Controls.Border? fill = FindVisualChildByName<System.Windows.Controls.Border>(progressBar, "PART_Fill");
                 Assert.IsNotNull(fill, "ProgressBar template must expose PART_Fill.");
 
                 SolidColorBrush? expected = app?.TryFindResource(brushKey) as SolidColorBrush;

--- a/Fluence.Wpf.Tests/ControlTests.RatingControl.cs
+++ b/Fluence.Wpf.Tests/ControlTests.RatingControl.cs
@@ -33,8 +33,6 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Input;
 using System.Windows.Media;
-using WpfStackPanel = System.Windows.Controls.StackPanel;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -62,7 +60,7 @@ namespace Fluence.Wpf.Tests
                 DrainDispatcher(w.Dispatcher);
 
                 // PART_StarsPanel must be present after template is applied.
-                WpfStackPanel? panel = FindVisualChildByName<WpfStackPanel>(rc, "PART_StarsPanel");
+                System.Windows.Controls.StackPanel? panel = FindVisualChildByName<System.Windows.Controls.StackPanel>(rc, "PART_StarsPanel");
                 Assert.IsNotNull(panel, "PART_StarsPanel must be present in RatingControl template.");
                 w.Close();
             });
@@ -81,7 +79,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfStackPanel? panel = FindVisualChildByName<WpfStackPanel>(rc, "PART_StarsPanel");
+                System.Windows.Controls.StackPanel? panel = FindVisualChildByName<System.Windows.Controls.StackPanel>(rc, "PART_StarsPanel");
                 Assert.IsNotNull(panel);
                 Assert.AreEqual(5, panel.Children.Count,
                     "Default MaxRating=5 must generate 5 star TextBlocks.");
@@ -102,12 +100,12 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfStackPanel? panel = FindVisualChildByName<WpfStackPanel>(rc, "PART_StarsPanel");
+                System.Windows.Controls.StackPanel? panel = FindVisualChildByName<System.Windows.Controls.StackPanel>(rc, "PART_StarsPanel");
                 Assert.IsNotNull(panel);
 
                 // Stars 1-3 must be filled (U+E735), stars 4-5 must be empty (U+E734).
                 int filledCount = 0;
-                foreach (WpfTextBlock star in panel.Children)
+                foreach (System.Windows.Controls.TextBlock star in panel.Children)
                 {
                     if (string.Equals(star.Text, "\uE735", System.StringComparison.Ordinal))
                     {
@@ -134,14 +132,14 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfStackPanel? panel = FindVisualChildByName<WpfStackPanel>(rc, "PART_StarsPanel");
+                System.Windows.Controls.StackPanel? panel = FindVisualChildByName<System.Windows.Controls.StackPanel>(rc, "PART_StarsPanel");
                 Assert.IsNotNull(panel);
 
                 SolidColorBrush? accentBrush = app?.TryFindResource("AccentFillColorDefaultBrush") as SolidColorBrush;
                 Assert.IsNotNull(accentBrush, "AccentFillColorDefaultBrush must resolve.");
 
                 // First two stars (filled) must use AccentFillColorDefaultBrush.
-                WpfTextBlock? star1 = panel.Children[0] as WpfTextBlock;
+                System.Windows.Controls.TextBlock? star1 = panel.Children[0] as System.Windows.Controls.TextBlock;
                 SolidColorBrush? star1Fg = star1?.Foreground as SolidColorBrush;
                 Assert.IsNotNull(star1Fg, "First filled star Foreground must be a SolidColorBrush.");
                 Assert.AreEqual(accentBrush.Color, star1Fg.Color,
@@ -163,13 +161,13 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfStackPanel? panel = FindVisualChildByName<WpfStackPanel>(rc, "PART_StarsPanel");
+                System.Windows.Controls.StackPanel? panel = FindVisualChildByName<System.Windows.Controls.StackPanel>(rc, "PART_StarsPanel");
                 Assert.IsNotNull(panel);
 
                 SolidColorBrush? secondaryBrush = app?.TryFindResource("TextFillColorSecondaryBrush") as SolidColorBrush;
                 Assert.IsNotNull(secondaryBrush, "TextFillColorSecondaryBrush must resolve.");
 
-                WpfTextBlock? star = panel.Children[0] as WpfTextBlock;
+                System.Windows.Controls.TextBlock? star = panel.Children[0] as System.Windows.Controls.TextBlock;
                 SolidColorBrush? starFg = star?.Foreground as SolidColorBrush;
                 Assert.IsNotNull(starFg, "Empty star Foreground must be a SolidColorBrush.");
                 Assert.AreEqual(secondaryBrush.Color, starFg.Color,
@@ -191,7 +189,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? caption = FindVisualChildByName<WpfTextBlock>(rc, "PART_Caption");
+                System.Windows.Controls.TextBlock? caption = FindVisualChildByName<System.Windows.Controls.TextBlock>(rc, "PART_Caption");
                 Assert.IsNotNull(caption, "PART_Caption must be present.");
                 Assert.AreEqual(Visibility.Visible, caption.Visibility,
                     "PART_Caption must be Visible when Caption is set.");
@@ -214,7 +212,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? caption = FindVisualChildByName<WpfTextBlock>(rc, "PART_Caption");
+                System.Windows.Controls.TextBlock? caption = FindVisualChildByName<System.Windows.Controls.TextBlock>(rc, "PART_Caption");
                 Assert.IsNotNull(caption, "PART_Caption must be present.");
                 Assert.AreEqual(Visibility.Collapsed, caption.Visibility,
                     "PART_Caption must be Collapsed when Caption is empty.");
@@ -261,7 +259,7 @@ namespace Fluence.Wpf.Tests
                 ThemeTestHelpers.ApplyStandardThemeCycle();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfStackPanel? panel = FindVisualChildByName<WpfStackPanel>(rc, "PART_StarsPanel");
+                System.Windows.Controls.StackPanel? panel = FindVisualChildByName<System.Windows.Controls.StackPanel>(rc, "PART_StarsPanel");
                 Assert.IsNotNull(panel,
                     "PART_StarsPanel must still be present after theme cycle.");
                 w.Close();

--- a/Fluence.Wpf.Tests/ControlTests.Separator.cs
+++ b/Fluence.Wpf.Tests/ControlTests.Separator.cs
@@ -30,7 +30,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using FluenceSeparator = Fluence.Wpf.Controls.Separator;
 
 namespace Fluence.Wpf.Tests
 {
@@ -52,7 +51,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceSeparator sep = new();
+                Controls.Separator sep = new();
                 Window w = new() { Content = sep, Width = 300, Height = 100 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -72,7 +71,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceSeparator sep = new();
+                Controls.Separator sep = new();
                 Window w = new() { Content = sep, Width = 300, Height = 100 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -91,7 +90,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceSeparator sep = new();
+                Controls.Separator sep = new();
                 Window w = new() { Content = sep, Width = 300, Height = 100 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -115,7 +114,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceSeparator sep = new();
+                Controls.Separator sep = new();
                 Window w = new() { Content = sep, Width = 300, Height = 100 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);

--- a/Fluence.Wpf.Tests/ControlTests.SplitButton.cs
+++ b/Fluence.Wpf.Tests/ControlTests.SplitButton.cs
@@ -32,9 +32,6 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfButton = System.Windows.Controls.Button;
-using WpfToggleButton = System.Windows.Controls.Primitives.ToggleButton;
 
 namespace Fluence.Wpf.Tests
 {
@@ -131,8 +128,8 @@ namespace Fluence.Wpf.Tests
                     window.UpdateLayout();
 
                     _ = button.ApplyTemplate();
-                    WpfButton? primaryButton = button.Template.FindName("PART_PrimaryButton", button) as WpfButton;
-                    WpfToggleButton? secondaryButton = button.Template.FindName("PART_SecondaryButton", button) as WpfToggleButton;
+                    System.Windows.Controls.Button? primaryButton = button.Template.FindName("PART_PrimaryButton", button) as System.Windows.Controls.Button;
+                    System.Windows.Controls.Primitives.ToggleButton? secondaryButton = button.Template.FindName("PART_SecondaryButton", button) as System.Windows.Controls.Primitives.ToggleButton;
                     Style? focusVisualStyle = app?.TryFindResource("DefaultControlFocusVisualStyle") as Style;
 
                     Assert.IsNotNull(primaryButton, "SplitButton template should expose PART_PrimaryButton.");
@@ -142,9 +139,9 @@ namespace Fluence.Wpf.Tests
                         "The primary half must use the FocusVisualStyle adorner so the focus ring shows only for keyboard navigation, never on click.");
                     Assert.AreSame(focusVisualStyle, secondaryButton.FocusVisualStyle,
                         "The secondary half must use the FocusVisualStyle adorner so the focus ring shows only for keyboard navigation, never on click.");
-                    Assert.IsNull(FindVisualChildByName<WpfBorder>(button, "PrimaryFocusOuter"),
+                    Assert.IsNull(FindVisualChildByName<System.Windows.Controls.Border>(button, "PrimaryFocusOuter"),
                         "The always-on in-template primary focus borders must be gone; they rendered on mouse click.");
-                    Assert.IsNull(FindVisualChildByName<WpfBorder>(button, "SecondaryFocusOuter"),
+                    Assert.IsNull(FindVisualChildByName<System.Windows.Controls.Border>(button, "SecondaryFocusOuter"),
                         "The always-on in-template secondary focus borders must be gone; they rendered on mouse click.");
                 }
                 finally

--- a/Fluence.Wpf.Tests/ControlTests.TabView.cs
+++ b/Fluence.Wpf.Tests/ControlTests.TabView.cs
@@ -30,7 +30,6 @@ using Fluence.Wpf.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
 using System.Windows.Controls;
-using WpfRepeatButton = System.Windows.Controls.Primitives.RepeatButton;
 
 namespace Fluence.Wpf.Tests
 {
@@ -58,7 +57,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfRepeatButton? btn = FindVisualChildByName<WpfRepeatButton>(tv, "PART_ScrollBackButton");
+                System.Windows.Controls.Primitives.RepeatButton? btn = FindVisualChildByName<System.Windows.Controls.Primitives.RepeatButton>(tv, "PART_ScrollBackButton");
                 Assert.IsNotNull(btn, "PART_ScrollBackButton (RepeatButton) must exist in TabView template.");
                 w.Close();
             });
@@ -79,7 +78,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfRepeatButton? btn = FindVisualChildByName<WpfRepeatButton>(tv, "PART_ScrollForwardButton");
+                System.Windows.Controls.Primitives.RepeatButton? btn = FindVisualChildByName<System.Windows.Controls.Primitives.RepeatButton>(tv, "PART_ScrollForwardButton");
                 Assert.IsNotNull(btn, "PART_ScrollForwardButton (RepeatButton) must exist in TabView template.");
                 w.Close();
             });
@@ -121,8 +120,8 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfRepeatButton? back = FindVisualChildByName<WpfRepeatButton>(tv, "PART_ScrollBackButton");
-                WpfRepeatButton? fwd = FindVisualChildByName<WpfRepeatButton>(tv, "PART_ScrollForwardButton");
+                System.Windows.Controls.Primitives.RepeatButton? back = FindVisualChildByName<System.Windows.Controls.Primitives.RepeatButton>(tv, "PART_ScrollBackButton");
+                System.Windows.Controls.Primitives.RepeatButton? fwd = FindVisualChildByName<System.Windows.Controls.Primitives.RepeatButton>(tv, "PART_ScrollForwardButton");
                 Assert.IsNotNull(back, "PART_ScrollBackButton must be in template.");
                 Assert.IsNotNull(fwd, "PART_ScrollForwardButton must be in template.");
 

--- a/Fluence.Wpf.Tests/ControlTests.TextBox.cs
+++ b/Fluence.Wpf.Tests/ControlTests.TextBox.cs
@@ -33,10 +33,6 @@ using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using FluencePasswordBox = Fluence.Wpf.Controls.PasswordBox;
-using FluenceTextBox = Fluence.Wpf.Controls.TextBox;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -59,12 +55,12 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new() { PlaceholderText = "Search…", PlaceholderEnabled = true };
+                Controls.TextBox tb = new() { PlaceholderText = "Search…", PlaceholderEnabled = true };
                 Window w = new() { Content = tb, Width = 300, Height = 60 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? placeholder = FindVisualChildByName<WpfTextBlock>(tb, "PlaceholderTextBlock");
+                TextBlock? placeholder = FindVisualChildByName<TextBlock>(tb, "PlaceholderTextBlock");
                 Assert.IsNotNull(placeholder, "PlaceholderTextBlock must be present in TextBox template.");
 
                 SolidColorBrush? expected = app?.TryFindResource("TextFillColorTertiaryBrush") as SolidColorBrush;
@@ -88,12 +84,12 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluencePasswordBox pb = new() { PlaceholderText = "Password" };
+                Controls.PasswordBox pb = new() { PlaceholderText = "Password" };
                 Window w = new() { Content = pb, Width = 300, Height = 60 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? placeholder = FindVisualChildByName<WpfTextBlock>(pb, "PlaceholderTextBlock");
+                TextBlock? placeholder = FindVisualChildByName<TextBlock>(pb, "PlaceholderTextBlock");
                 Assert.IsNotNull(placeholder, "PlaceholderTextBlock must be present in PasswordBox template.");
 
                 SolidColorBrush? expected = app?.TryFindResource("TextFillColorTertiaryBrush") as SolidColorBrush;
@@ -117,15 +113,15 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluencePasswordBox pb = new() { PlaceholderText = "Password" };
+                Controls.PasswordBox pb = new() { PlaceholderText = "Password" };
                 Window w = new() { Content = pb, Width = 300, Height = 60 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                MethodInfo? startCapsPoll = typeof(FluencePasswordBox).GetMethod(
+                MethodInfo? startCapsPoll = typeof(Controls.PasswordBox).GetMethod(
                     "StartCapsPoll",
                     BindingFlags.Instance | BindingFlags.NonPublic);
-                FieldInfo? capsPollTimer = typeof(FluencePasswordBox).GetField(
+                FieldInfo? capsPollTimer = typeof(Controls.PasswordBox).GetField(
                     "_capsPollTimer",
                     BindingFlags.Instance | BindingFlags.NonPublic);
                 Assert.IsNotNull(startCapsPoll, "PasswordBox must expose the expected internal caps-poll start method.");
@@ -150,7 +146,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new() { PlaceholderText = "Hint", PlaceholderEnabled = true };
+                Controls.TextBox tb = new() { PlaceholderText = "Hint", PlaceholderEnabled = true };
                 Window w = new() { Content = tb, Width = 300, Height = 60 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -158,7 +154,7 @@ namespace Fluence.Wpf.Tests
                 ThemeTestHelpers.ApplyStandardThemeCycle();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? placeholder = FindVisualChildByName<WpfTextBlock>(tb, "PlaceholderTextBlock");
+                TextBlock? placeholder = FindVisualChildByName<TextBlock>(tb, "PlaceholderTextBlock");
                 Assert.IsNotNull(placeholder, "PlaceholderTextBlock must remain present after theme cycle.");
 
                 SolidColorBrush? expected = app?.TryFindResource("TextFillColorTertiaryBrush") as SolidColorBrush;
@@ -182,7 +178,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     ValidationState = ValidationState.Error,
@@ -192,7 +188,7 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? validationLine = FindVisualChildByName<WpfBorder>(tb, "PART_ValidationLine");
+                Border? validationLine = FindVisualChildByName<Border>(tb, "PART_ValidationLine");
                 Assert.IsNotNull(validationLine, "TextBox template must expose PART_ValidationLine.");
                 Assert.AreEqual(0.0, validationLine.Opacity, 0.001, "Validation underline should be hidden before focus.");
 
@@ -219,7 +215,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     HelperText = "Helper text",
@@ -229,9 +225,9 @@ namespace Fluence.Wpf.Tests
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfTextBlock? helper = FindVisualChildByName<WpfTextBlock>(tb, "PART_HelperText");
+                TextBlock? helper = FindVisualChildByName<TextBlock>(tb, "PART_HelperText");
                 Assert.IsNotNull(helper, "TextBox template must expose PART_HelperText.");
-                WpfTextBlock? icon = FindVisualChildByName<WpfTextBlock>(tb, "PART_ValidationIcon");
+                TextBlock? icon = FindVisualChildByName<TextBlock>(tb, "PART_ValidationIcon");
                 Assert.IsNotNull(icon, "TextBox template must expose PART_ValidationIcon.");
 
                 StackPanel? helperRow = VisualTreeHelper.GetParent(helper) as StackPanel;
@@ -259,7 +255,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     ValidationMessage = "Value is required",
@@ -287,7 +283,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     ValidationMessage = "Temp error",
@@ -319,7 +315,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     ValidationMessage = "Check the value",
@@ -347,7 +343,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     ValidationMessage = "Value is required",
@@ -399,7 +395,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTextBox tb = new()
+                Controls.TextBox tb = new()
                 {
                     Width = 240,
                     ValidationMessage = "Value is required",

--- a/Fluence.Wpf.Tests/ControlTests.ToggleButton.cs
+++ b/Fluence.Wpf.Tests/ControlTests.ToggleButton.cs
@@ -389,7 +389,7 @@ namespace Fluence.Wpf.Tests
         private static bool IsToggleHoverTrigger(TriggerBase triggerBase, object? isCheckedValue)
         {
             return triggerBase is MultiTrigger multiTrigger
-                && multiTrigger.Conditions.Count == 3
+                && multiTrigger.Conditions.Count is 3
                 && HasTriggerCondition(multiTrigger, System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty, isCheckedValue)
                 && HasTriggerCondition(multiTrigger, UIElement.IsMouseOverProperty, value: true)
                 && HasTriggerCondition(multiTrigger, System.Windows.Controls.Primitives.ButtonBase.IsPressedProperty, value: false);
@@ -398,7 +398,7 @@ namespace Fluence.Wpf.Tests
         private static bool IsTogglePressedTrigger(TriggerBase triggerBase, object? isCheckedValue)
         {
             return triggerBase is MultiTrigger multiTrigger
-                && multiTrigger.Conditions.Count == 2
+                && multiTrigger.Conditions.Count is 2
                 && HasTriggerCondition(multiTrigger, System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty, isCheckedValue)
                 && HasTriggerCondition(multiTrigger, System.Windows.Controls.Primitives.ButtonBase.IsPressedProperty, value: true);
         }

--- a/Fluence.Wpf.Tests/ControlTests.TreeView.cs
+++ b/Fluence.Wpf.Tests/ControlTests.TreeView.cs
@@ -32,9 +32,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
-using FluenceTreeView = Fluence.Wpf.Controls.TreeView;
-using FluenceTreeViewItem = Fluence.Wpf.Controls.TreeViewItem;
-using WpfBorder = System.Windows.Controls.Border;
 
 namespace Fluence.Wpf.Tests
 {
@@ -56,9 +53,9 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeView tv = new();
-                _ = tv.Items.Add(new FluenceTreeViewItem { Header = "Node 1" });
-                _ = tv.Items.Add(new FluenceTreeViewItem { Header = "Node 2" });
+                Controls.TreeView tv = new();
+                _ = tv.Items.Add(new Controls.TreeViewItem { Header = "Node 1" });
+                _ = tv.Items.Add(new Controls.TreeViewItem { Header = "Node 2" });
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -82,9 +79,9 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Node A" };
-                _ = item.Items.Add(new FluenceTreeViewItem { Header = "Child 1" });
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Node A" };
+                _ = item.Items.Add(new Controls.TreeViewItem { Header = "Child 1" });
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
@@ -108,9 +105,9 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Node A" };
-                _ = item.Items.Add(new FluenceTreeViewItem { Header = "Child 1" });
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Node A" };
+                _ = item.Items.Add(new Controls.TreeViewItem { Header = "Child 1" });
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
@@ -134,8 +131,8 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Leaf" };
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Leaf" };
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
@@ -158,9 +155,9 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Node A" };
-                _ = item.Items.Add(new FluenceTreeViewItem { Header = "Child 1" });
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Node A" };
+                _ = item.Items.Add(new Controls.TreeViewItem { Header = "Child 1" });
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
@@ -191,14 +188,14 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Node A" };
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Node A" };
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
 
-                WpfBorder? itemBorder = FindVisualChildByName<WpfBorder>(item, "ItemBorder");
+                Border? itemBorder = FindVisualChildByName<Border>(item, "ItemBorder");
                 Assert.IsNotNull(itemBorder, "ItemBorder must exist in TreeViewItem template.");
 
                 // Background must be transparent (or null) in normal state
@@ -227,9 +224,9 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Parent" };
-                _ = item.Items.Add(new FluenceTreeViewItem { Header = "Child" });
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Parent" };
+                _ = item.Items.Add(new Controls.TreeViewItem { Header = "Child" });
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
@@ -289,8 +286,8 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeView tv = new();
-                _ = tv.Items.Add(new FluenceTreeViewItem { Header = "Node 1" });
+                Controls.TreeView tv = new();
+                _ = tv.Items.Add(new Controls.TreeViewItem { Header = "Node 1" });
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();
                 DrainDispatcher(w.Dispatcher);
@@ -315,9 +312,9 @@ namespace Fluence.Wpf.Tests
                 Application? app = EnsureApplication();
                 _ = MergeGenericDictionary(app);
 
-                FluenceTreeViewItem item = new() { Header = "Node A" };
-                _ = item.Items.Add(new FluenceTreeViewItem { Header = "Child" });
-                FluenceTreeView tv = new();
+                Controls.TreeViewItem item = new() { Header = "Node A" };
+                _ = item.Items.Add(new Controls.TreeViewItem { Header = "Child" });
+                Controls.TreeView tv = new();
                 _ = tv.Items.Add(item);
                 Window w = new() { Content = tv, Width = 300, Height = 200 };
                 w.Show();

--- a/Fluence.Wpf.Tests/ControlTests.TreeViewSelectionMode.cs
+++ b/Fluence.Wpf.Tests/ControlTests.TreeViewSelectionMode.cs
@@ -29,9 +29,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
 using System.Windows.Input;
-using FluentTreeView = Fluence.Wpf.Controls.TreeView;
-using FluentTreeViewItem = Fluence.Wpf.Controls.TreeViewItem;
-using WpfCheckBox = System.Windows.Controls.CheckBox;
 
 namespace Fluence.Wpf.Tests
 {
@@ -47,7 +44,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    FluentTreeView treeView = new();
+                    Controls.TreeView treeView = new();
 
                     Assert.AreEqual(TreeViewSelectionMode.Single, treeView.SelectionMode);
                     Assert.IsNotNull(treeView.SelectedItems, "SelectedItems should be a live collection.");
@@ -74,9 +71,9 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    FluentTreeViewItem first = new() { Header = "First" };
-                    FluentTreeViewItem second = new() { Header = "Second" };
-                    FluentTreeView treeView = new()
+                    Controls.TreeViewItem first = new() { Header = "First" };
+                    Controls.TreeViewItem second = new() { Header = "Second" };
+                    Controls.TreeView treeView = new()
                     {
                         SelectionMode = TreeViewSelectionMode.Multiple,
                     };
@@ -89,7 +86,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfCheckBox? firstCheckBox = FindVisualChildByName<WpfCheckBox>(first, "SelectionCheckBox");
+                    System.Windows.Controls.CheckBox? firstCheckBox = FindVisualChildByName<System.Windows.Controls.CheckBox>(first, "SelectionCheckBox");
                     Assert.IsNotNull(firstCheckBox, "Multiple-selection TreeViewItem template should expose a checkbox.");
                     Assert.AreEqual(Visibility.Visible, firstCheckBox.Visibility,
                         "TreeViewItem checkbox should be visible when the owning TreeView is in Multiple mode.");
@@ -133,8 +130,8 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    FluentTreeViewItem item = new() { Header = "Contracts" };
-                    FluentTreeView treeView = new()
+                    Controls.TreeViewItem item = new() { Header = "Contracts" };
+                    Controls.TreeView treeView = new()
                     {
                         SelectionMode = TreeViewSelectionMode.Multiple,
                     };
@@ -150,8 +147,8 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    FluentTreeViewItem keyboardItem =
-                        treeView.ItemContainerGenerator.ContainerFromItem(item) as FluentTreeViewItem ?? item;
+                    Controls.TreeViewItem keyboardItem =
+                        treeView.ItemContainerGenerator.ContainerFromItem(item) as Controls.TreeViewItem ?? item;
 
                     _ = keyboardItem.ApplyTemplate();
                     _ = keyboardItem.Focus();
@@ -196,8 +193,8 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    FluentTreeViewItem item = new() { Header = "Leaf" };
-                    FluentTreeView treeView = new()
+                    Controls.TreeViewItem item = new() { Header = "Leaf" };
+                    Controls.TreeView treeView = new()
                     {
                         SelectionMode = TreeViewSelectionMode.Multiple,
                     };
@@ -216,7 +213,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfCheckBox? checkBox = FindVisualChildByName<WpfCheckBox>(item, "SelectionCheckBox");
+                    System.Windows.Controls.CheckBox? checkBox = FindVisualChildByName<System.Windows.Controls.CheckBox>(item, "SelectionCheckBox");
                     Assert.IsNotNull(checkBox, "TreeViewItem template should keep the checkbox part available.");
                     Assert.AreEqual(Visibility.Collapsed, checkBox.Visibility,
                         "TreeViewItem checkbox should be hidden when selection is disabled.");
@@ -247,15 +244,15 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    FluentTreeViewItem parent = new() { Header = "Documents", IsExpanded = true };
-                    FluentTreeViewItem first = new() { Header = "Contracts" };
-                    FluentTreeViewItem second = new() { Header = "Invoices" };
-                    FluentTreeViewItem third = new() { Header = "Receipts" };
+                    Controls.TreeViewItem parent = new() { Header = "Documents", IsExpanded = true };
+                    Controls.TreeViewItem first = new() { Header = "Contracts" };
+                    Controls.TreeViewItem second = new() { Header = "Invoices" };
+                    Controls.TreeViewItem third = new() { Header = "Receipts" };
                     _ = parent.Items.Add(first);
                     _ = parent.Items.Add(second);
                     _ = parent.Items.Add(third);
 
-                    FluentTreeView treeView = new()
+                    Controls.TreeView treeView = new()
                     {
                         SelectionMode = TreeViewSelectionMode.Multiple,
                     };

--- a/Fluence.Wpf.Tests/ControlTests.cs
+++ b/Fluence.Wpf.Tests/ControlTests.cs
@@ -1503,7 +1503,7 @@ namespace Fluence.Wpf.Tests
 
                     Assert.IsNotNull(toggle);
                     Assert.IsNotNull(label);
-                    Assert.IsTrue(toggle.IsChecked == true, "ThemeWatcherToggle should default to checked.");
+                    Assert.IsTrue(toggle.IsChecked is true, "ThemeWatcherToggle should default to checked.");
                     Assert.AreEqual("Watching: Yes", label.Text);
 
                     toggle.IsChecked = false;
@@ -2570,7 +2570,7 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    Assert.IsTrue(radio1.IsChecked == true);
+                    Assert.IsTrue(radio1.IsChecked is true);
 
                     radio2.IsChecked = true;
                     DrainDispatcher(window.Dispatcher);

--- a/Fluence.Wpf.Tests/ControlTests.cs
+++ b/Fluence.Wpf.Tests/ControlTests.cs
@@ -2792,8 +2792,8 @@ namespace Fluence.Wpf.Tests
 
             window.NavigateTo(itemContent);
             DrainDispatcher(dispatcher);
-            dispatcher.Invoke(new Action(static delegate { }), DispatcherPriority.Loaded);
-            dispatcher.Invoke(new Action(static delegate { }), DispatcherPriority.ContextIdle);
+            dispatcher.Invoke(new Action(static delegate { }), DispatcherPriority.Loaded, default);
+            dispatcher.Invoke(new Action(static delegate { }), DispatcherPriority.ContextIdle, default);
             window.UpdateLayout();
             DrainDispatcher(dispatcher);
 

--- a/Fluence.Wpf.Tests/DemoColorsPageTests.cs
+++ b/Fluence.Wpf.Tests/DemoColorsPageTests.cs
@@ -229,7 +229,7 @@ namespace Fluence.Wpf.Tests
             List<string> violations = [];
             foreach (string value in forbidden)
             {
-                if (source.IndexOf(value, StringComparison.Ordinal) >= 0)
+                if (source.Contains(value, StringComparison.Ordinal))
                 {
                     violations.Add(value);
                 }

--- a/Fluence.Wpf.Tests/DemoMainWindowTests.cs
+++ b/Fluence.Wpf.Tests/DemoMainWindowTests.cs
@@ -43,11 +43,6 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
-using FluenceExpander = Fluence.Wpf.Controls.Expander;
-using FluenceListView = Fluence.Wpf.Controls.ListView;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfButton = System.Windows.Controls.Button;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -549,25 +544,25 @@ namespace Fluence.Wpf.Tests
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should use the shared TitleBar control.");
 
-                    WpfButton? titleBarToggle = FindByName<WpfButton>(shellTitleBar, "PART_PaneToggleButton");
+                    System.Windows.Controls.Button? titleBarToggle = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_PaneToggleButton");
                     Assert.IsNotNull(titleBarToggle, "Extended title bar should expose a pane toggle button.");
                     Assert.AreEqual(Visibility.Visible, titleBarToggle.Visibility,
                         "Pane toggle should move into the title bar when content extends into the title bar.");
                     Assert.AreEqual(40.0, titleBarToggle.ActualWidth, 0.5,
                         "Title-bar pane toggle should match the WinUI-canonical 40 px glyph button width.");
 
-                    WpfTextBlock? titleBarGlyph = FindVisualChild<WpfTextBlock>(titleBarToggle);
+                    System.Windows.Controls.TextBlock? titleBarGlyph = FindVisualChild<System.Windows.Controls.TextBlock>(titleBarToggle);
                     Assert.IsNotNull(titleBarGlyph, "Title-bar pane toggle should render a Segoe Fluent Icons glyph.");
                     Assert.AreEqual(16.0, titleBarGlyph.FontSize, 0.01,
                         "Title-bar pane toggle glyph should match the compact title-bar glyph style.");
 
-                    WpfButton? titleBarBack = FindByName<WpfButton>(shellTitleBar, "PART_BackButton");
+                    System.Windows.Controls.Button? titleBarBack = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_BackButton");
                     Assert.IsNotNull(titleBarBack, "Extended title bar should expose a back button slot.");
                     Assert.AreEqual(Visibility.Visible, titleBarBack.Visibility,
                         "Visited-page history should make the title-bar back slot visible in Left mode.");
                     Assert.IsLessThan(GetVisualX(titleBarToggle, window) ?? double.MaxValue, GetVisualX(titleBarBack, window) ?? double.MaxValue,
                         "Back should occupy the first title-bar navigation slot.");
-                    WpfTextBlock? titleBarBackGlyph = FindVisualChild<WpfTextBlock>(titleBarBack);
+                    System.Windows.Controls.TextBlock? titleBarBackGlyph = FindVisualChild<System.Windows.Controls.TextBlock>(titleBarBack);
                     Assert.IsNotNull(titleBarBackGlyph, "Title-bar back button should render a Segoe Fluent Icons glyph.");
 
                     NavigationViewItem? firstItem = nav.Items.Count > 0 ? nav.Items[0] as NavigationViewItem : null;
@@ -591,7 +586,7 @@ namespace Fluence.Wpf.Tests
                         "Title identity should start after the title-bar navigation slot.");
 
                     _ = nav.ApplyTemplate();
-                    WpfButton? internalToggle = nav.Template.FindName(NavigationView.PartPaneToggleButton, nav) as WpfButton;
+                    System.Windows.Controls.Button? internalToggle = nav.Template.FindName(NavigationView.PartPaneToggleButton, nav) as System.Windows.Controls.Button;
                     Assert.IsNotNull(internalToggle, "Internal NavigationView pane toggle should still exist in the template.");
                     Assert.AreEqual(Visibility.Collapsed, internalToggle.Visibility,
                         "Internal NavigationView pane toggle should be hidden while title-bar chrome owns it.");
@@ -626,8 +621,8 @@ namespace Fluence.Wpf.Tests
 
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should use the shared TitleBar control.");
-                    WpfButton? titleBarBack = FindByName<WpfButton>(shellTitleBar, "PART_BackButton");
-                    WpfButton? titleBarToggle = FindByName<WpfButton>(shellTitleBar, "PART_PaneToggleButton");
+                    System.Windows.Controls.Button? titleBarBack = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_BackButton");
+                    System.Windows.Controls.Button? titleBarToggle = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_PaneToggleButton");
                     Assert.IsNotNull(titleBarBack, "Extended title bar should expose a back button.");
                     Assert.IsNotNull(titleBarToggle, "Extended title bar should expose a pane toggle button.");
                     Assert.AreEqual(Visibility.Visible, titleBarBack.Visibility,
@@ -732,15 +727,15 @@ namespace Fluence.Wpf.Tests
 
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Demo shell should expose a TitleBar.");
-                    WpfButton? titleBarToggle = FindByName<WpfButton>(shellTitleBar, "PART_PaneToggleButton");
+                    System.Windows.Controls.Button? titleBarToggle = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_PaneToggleButton");
                     Assert.IsNotNull(titleBarToggle, "TitleBar should expose a pane toggle slot.");
                     Assert.AreEqual(Visibility.Collapsed, titleBarToggle.Visibility,
                         "Top mode should not show a pane toggle in the title bar.");
-                    WpfButton? titleBarBack = FindByName<WpfButton>(shellTitleBar, "PART_BackButton");
+                    System.Windows.Controls.Button? titleBarBack = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_BackButton");
                     Assert.IsNotNull(titleBarBack, "TitleBar should expose a back button slot.");
                     Assert.AreEqual(Visibility.Visible, titleBarBack.Visibility,
                         "Top mode should move the requested back button into the title bar.");
-                    WpfTextBlock? titleBarBackGlyph = FindVisualChild<WpfTextBlock>(titleBarBack);
+                    System.Windows.Controls.TextBlock? titleBarBackGlyph = FindVisualChild<System.Windows.Controls.TextBlock>(titleBarBack);
                     Assert.IsNotNull(titleBarBackGlyph, "Title-bar back button should render a Segoe Fluent Icons glyph.");
                     Assert.AreEqual(16.0, titleBarBackGlyph.FontSize, 0.01,
                         "Title-bar back glyph should match the compact title-bar glyph style.");
@@ -756,8 +751,8 @@ namespace Fluence.Wpf.Tests
                         "Top mode back should appear before centered title-bar content.");
 
                     _ = nav.ApplyTemplate();
-                    WpfButton? internalBack = nav.Template.FindName(NavigationView.PartBackButton, nav) as WpfButton;
-                    WpfButton? internalToggle = nav.Template.FindName(NavigationView.PartPaneToggleButton, nav) as WpfButton;
+                    System.Windows.Controls.Button? internalBack = nav.Template.FindName(NavigationView.PartBackButton, nav) as System.Windows.Controls.Button;
+                    System.Windows.Controls.Button? internalToggle = nav.Template.FindName(NavigationView.PartPaneToggleButton, nav) as System.Windows.Controls.Button;
                     Assert.IsNotNull(internalBack, "Internal NavigationView back button should exist.");
                     Assert.AreEqual(Visibility.Collapsed, internalBack.Visibility,
                         "Demo shell should suppress the internal Top pane back button while the title bar owns back navigation.");
@@ -1110,7 +1105,7 @@ namespace Fluence.Wpf.Tests
 
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should expose the shell pane toggle.");
-                    WpfButton? titleBarToggle = FindByName<WpfButton>(shellTitleBar, "PART_PaneToggleButton");
+                    System.Windows.Controls.Button? titleBarToggle = FindByName<System.Windows.Controls.Button>(shellTitleBar, "PART_PaneToggleButton");
                     Assert.IsNotNull(titleBarToggle, "Shell title bar should expose a pane toggle button in Left navigation.");
                     Assert.AreEqual(Visibility.Visible, titleBarToggle.Visibility,
                         "The shell pane toggle should be visible in Left navigation.");
@@ -1168,7 +1163,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsNotNull(nav, "Navigation page should expose the compact sample NavigationView.");
                     Assert.IsFalse(nav.IsPaneOpen, "Compact sample should start collapsed.");
 
-                    WpfButton? paneToggle = nav.Template.FindName(NavigationView.PartPaneToggleButton, nav) as WpfButton;
+                    System.Windows.Controls.Button? paneToggle = nav.Template.FindName(NavigationView.PartPaneToggleButton, nav) as System.Windows.Controls.Button;
                     Assert.IsNotNull(paneToggle, "Compact sample should expose the pane toggle button.");
 
                     Controls.Button? sampleToggle = FindByName<Controls.Button>(page, "CompactPaneToggleButton");
@@ -1223,7 +1218,7 @@ namespace Fluence.Wpf.Tests
 
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should use the shared TitleBar control.");
-                    WpfTextBlock? titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
+                    System.Windows.Controls.TextBlock? titleText = FindByName<System.Windows.Controls.TextBlock>(shellTitleBar, "PART_TitleText");
                     Controls.TextBox? search = FindByName<Controls.TextBox>(window, "NavSearchBox");
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
                     Assert.IsNotNull(search, "Demo search box must be present.");
@@ -1273,7 +1268,7 @@ namespace Fluence.Wpf.Tests
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should use the shared TitleBar control.");
                     ContentPresenter? titleIcon = FindByName<ContentPresenter>(shellTitleBar, "PART_IconPresenter");
-                    WpfTextBlock? titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
+                    System.Windows.Controls.TextBlock? titleText = FindByName<System.Windows.Controls.TextBlock>(shellTitleBar, "PART_TitleText");
                     Assert.IsNotNull(titleIcon, "Extended title bar icon should exist.");
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
                     Assert.AreEqual(Visibility.Visible, titleIcon.Visibility,
@@ -1328,7 +1323,7 @@ namespace Fluence.Wpf.Tests
                     Assert.AreEqual(window.ActualWidth / 2.0, GetVisualCenterX(search, window) ?? double.MaxValue, 1.0,
                         "Search should stay horizontally centered in the window even when title text is constrained.");
 
-                    WpfTextBlock? titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
+                    System.Windows.Controls.TextBlock? titleText = FindByName<System.Windows.Controls.TextBlock>(shellTitleBar, "PART_TitleText");
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
                     if (titleText.Visibility is Visibility.Visible)
                     {
@@ -1373,7 +1368,7 @@ namespace Fluence.Wpf.Tests
 
                     TitleBar? shellTitleBar = FindByName<TitleBar>(window, "ShellTitleBar");
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should use the shared TitleBar control.");
-                    WpfTextBlock? titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
+                    System.Windows.Controls.TextBlock? titleText = FindByName<System.Windows.Controls.TextBlock>(shellTitleBar, "PART_TitleText");
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
                     if (titleText.Visibility is Visibility.Visible)
                     {
@@ -1391,7 +1386,7 @@ namespace Fluence.Wpf.Tests
                     window.UpdateLayout();
                     Drain(window.Dispatcher);
 
-                    titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
+                    titleText = FindByName<System.Windows.Controls.TextBlock>(shellTitleBar, "PART_TitleText");
                     Controls.TextBox? search = FindByName<Controls.TextBox>(window, "NavSearchBox");
                     Assert.IsNotNull(search, "Demo search box must be present.");
                     Assert.AreEqual(Visibility.Visible, titleText?.Visibility,
@@ -1460,13 +1455,13 @@ namespace Fluence.Wpf.Tests
                     SampleDescription = "Snippet",
                     XamlSource = "<ui:Button Content=\"Save\" />",
                     CSharpSource = "private void Save_Click(object sender, RoutedEventArgs e) { }",
-                    DemoContent = new WpfTextBlock { Text = "Visible sample" },
+                    DemoContent = new System.Windows.Controls.TextBlock { Text = "Visible sample" },
                 };
 
                 Window window = CreateHostWindow(sample);
                 try
                 {
-                    FluenceExpander? expander = FindByName<FluenceExpander>(sample, "SourceExpander");
+                    Controls.Expander? expander = FindByName<Controls.Expander>(sample, "SourceExpander");
                     Assert.IsNotNull(expander, "Inline source expander must exist.");
                     Assert.IsFalse(expander.IsExpanded, "Source starts collapsed.");
 
@@ -1480,7 +1475,7 @@ namespace Fluence.Wpf.Tests
                     AssertSourceTab(tabs, "XAML", sample.XamlSource);
                     AssertSourceTab(tabs, "C#", sample.CSharpSource);
 
-                    WpfBorder? sampleCard = FindByName<WpfBorder>(sample, "SampleCard");
+                    System.Windows.Controls.Border? sampleCard = FindByName<System.Windows.Controls.Border>(sample, "SampleCard");
                     Assert.IsNotNull(sampleCard, "Sample host should expose the sample surface.");
                     Assert.AreEqual(new CornerRadius(8, 8, 0, 0), sampleCard.CornerRadius,
                         "Sample surface should square off its bottom corners so source attaches.");
@@ -1509,13 +1504,13 @@ namespace Fluence.Wpf.Tests
                     SampleDescription = "Snippet",
                     XamlSource = "<Grid>\n    <TextBlock Text=\"Indented\" />\n</Grid>",
                     CSharpSource = "private void Save()\n{\n    string value = \"Indented\";\n}",
-                    DemoContent = new WpfTextBlock { Text = "Visible sample" },
+                    DemoContent = new System.Windows.Controls.TextBlock { Text = "Visible sample" },
                 };
 
                 Window window = CreateHostWindow(sample);
                 try
                 {
-                    FluenceExpander? expander = FindByName<FluenceExpander>(sample, "SourceExpander");
+                    Controls.Expander? expander = FindByName<Controls.Expander>(sample, "SourceExpander");
                     Assert.IsNotNull(expander, "Inline source expander must exist.");
                     expander.IsExpanded = true;
                     Drain(window.Dispatcher);
@@ -1552,7 +1547,7 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
                 Window window = CreateHostWindow(sample);
                 try
                 {
-                    FluenceExpander? expander = FindByName<FluenceExpander>(sample, "SourceExpander");
+                    Controls.Expander? expander = FindByName<Controls.Expander>(sample, "SourceExpander");
                     _ = expander?.IsExpanded = true;
                     Drain(window.Dispatcher);
                     window.UpdateLayout();
@@ -1747,8 +1742,8 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
                     Controls.ProgressBar? progressBar = FindByName<Controls.ProgressBar>(page, "StepProgressBar");
                     Assert.IsNotNull(progressBar, "Status page should expose the step ProgressBar.");
 
-                    WpfBorder? track = FindByName<WpfBorder>(progressBar, "PART_Track");
-                    WpfBorder? fill = FindByName<WpfBorder>(progressBar, "PART_Fill");
+                    System.Windows.Controls.Border? track = FindByName<System.Windows.Controls.Border>(progressBar, "PART_Track");
+                    System.Windows.Controls.Border? fill = FindByName<System.Windows.Controls.Border>(progressBar, "PART_Fill");
                     Assert.IsNotNull(track, "Step ProgressBar should expose PART_Track.");
                     Assert.IsNotNull(fill, "Step ProgressBar should expose PART_Fill.");
 
@@ -1868,15 +1863,15 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
                     Grid? table = FindByName<Grid>(page, "TypographyTable");
                     Assert.IsNotNull(table, "Typography page should expose TypographyTable.");
 
-                    WpfTextBlock? firstBodyCell = table.Children
-                        .OfType<WpfTextBlock>()
+                    System.Windows.Controls.TextBlock? firstBodyCell = table.Children
+                        .OfType<System.Windows.Controls.TextBlock>()
                         .FirstOrDefault(static textBlock => Grid.GetRow(textBlock) is 1 && Grid.GetColumn(textBlock) is 0);
                     Assert.IsNotNull(firstBodyCell, "Typography table should include a first body row cell.");
                     Assert.AreEqual(new Thickness(24, 8, 16, 8), firstBodyCell.Margin,
                         "Typography body cells should use reduced vertical row spacing.");
 
-                    WpfBorder? firstShadedRow = table.Children
-                        .OfType<WpfBorder>()
+                    System.Windows.Controls.Border? firstShadedRow = table.Children
+                        .OfType<System.Windows.Controls.Border>()
                         .FirstOrDefault(static border => Grid.GetRow(border) is 1);
                     Assert.IsNotNull(firstShadedRow, "Typography table should include shaded row backgrounds.");
                     Assert.AreEqual(new Thickness(0, 2, 0, 2), firstShadedRow.Margin,
@@ -1927,9 +1922,9 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
                 Window window = CreateHostWindow(page);
                 try
                 {
-                    WpfBorder? appThemeCard = FindByName<WpfBorder>(page, "AppThemeSettingsCard");
-                    WpfBorder? backdropCard = FindByName<WpfBorder>(page, "BackdropSettingsCard");
-                    WpfBorder? colorsCard = FindByName<WpfBorder>(page, "ColorsSettingsCard");
+                    System.Windows.Controls.Border? appThemeCard = FindByName<System.Windows.Controls.Border>(page, "AppThemeSettingsCard");
+                    System.Windows.Controls.Border? backdropCard = FindByName<System.Windows.Controls.Border>(page, "BackdropSettingsCard");
+                    System.Windows.Controls.Border? colorsCard = FindByName<System.Windows.Controls.Border>(page, "ColorsSettingsCard");
                     System.Windows.Controls.ComboBox? backdrop = FindByName<System.Windows.Controls.ComboBox>(page, "BackdropComboBox");
                     UniformGrid? accentRow = FindByName<UniformGrid>(page, "AccentSwatchRow");
                     System.Windows.Controls.ComboBox? minimize = FindByName<System.Windows.Controls.ComboBox>(page, "MinimizeVisibilityCombo");
@@ -2196,11 +2191,11 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
                 Window window = CreateHostWindow(page);
                 try
                 {
-                    FluenceListView? list = FindByName<FluenceListView>(page, "IconCatalogList");
+                    Controls.ListView? list = FindByName<Controls.ListView>(page, "IconCatalogList");
                     Assert.IsNotNull(list, "Icon catalog list must exist.");
                     Assert.IsTrue(list.Items.Count > 100, "Icon catalog must load enough rows to exercise virtualization.");
 
-                    WpfBorder? catalogCard = FindByName<WpfBorder>(page, "IconCatalogCard");
+                    System.Windows.Controls.Border? catalogCard = FindByName<System.Windows.Controls.Border>(page, "IconCatalogCard");
                     Assert.IsNotNull(catalogCard, "Icon catalog should be hosted in the bordered gallery panel.");
                     Assert.AreEqual(new Thickness(0), catalogCard.Padding,
                         "Icon catalog panel should stay flush so the sidebar divider spans its full height.");
@@ -2215,7 +2210,7 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
                     Assert.AreEqual(new Thickness(0), list.BorderThickness,
                         "Icon catalog ListView should let the surrounding panel own the stroke.");
 
-                    WpfBorder? detailsPanel = FindByName<WpfBorder>(page, "IconDetailsPanel");
+                    System.Windows.Controls.Border? detailsPanel = FindByName<System.Windows.Controls.Border>(page, "IconDetailsPanel");
                     Assert.IsNotNull(detailsPanel, "Icon details sidebar should exist.");
                     Assert.AreEqual(new Thickness(1, 0, 0, 0), detailsPanel.BorderThickness,
                         "Icon details sidebar should be separated from the grid by a 1px vertical divider.");
@@ -2251,7 +2246,7 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
 
         private static void AssertTabViewItemContentSurface(TabViewItem item)
         {
-            WpfBorder? surface = item.Content as WpfBorder;
+            System.Windows.Controls.Border? surface = item.Content as System.Windows.Controls.Border;
             Assert.IsNotNull(surface, "TabView document content should use a layer-fill surface.");
             AssertIconBrush(surface.Background, "LayerFillColorDefaultBrush",
                 "TabView document content should use LayerFillColorDefaultBrush.");
@@ -2277,7 +2272,7 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
             {
                 if (item is TabItem tab && string.Equals(tab.Header as string, expectedHeader, StringComparison.Ordinal))
                 {
-                    WpfButton? copy = FindByName<WpfButton>(tab.Content as DependencyObject, "CopySourceButton");
+                    System.Windows.Controls.Button? copy = FindByName<System.Windows.Controls.Button>(tab.Content as DependencyObject, "CopySourceButton");
                     Assert.IsNotNull(copy, "Source tab should expose a copy button: " + expectedHeader);
                     Assert.AreEqual(expectedSource, copy.Tag as string, "Copy button should keep the in-memory source text.");
                     return;
@@ -2384,7 +2379,7 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
 
         private static void InvokeTitleBarBack(TitleBar titleBar)
         {
-            WpfButton? backButton = FindByName<WpfButton>(titleBar, "PART_BackButton");
+            System.Windows.Controls.Button? backButton = FindByName<System.Windows.Controls.Button>(titleBar, "PART_BackButton");
             Assert.IsNotNull(backButton, "TitleBar should expose a back button.");
             backButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, backButton));
             Drain(titleBar.Dispatcher);

--- a/Fluence.Wpf.Tests/DemoMainWindowTests.cs
+++ b/Fluence.Wpf.Tests/DemoMainWindowTests.cs
@@ -978,7 +978,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsNotNull(overflowButton, "Top pane should expose the overflow button.");
                     Assert.AreEqual(Visibility.Visible, overflowButton.Visibility,
                         "The overflow button should be visible at the minimum demo width.");
-                    int visibleNavigationItems = nav.Items.OfType<NavigationViewItem>().Count(static item => item.Visibility == Visibility.Visible);
+                    int visibleNavigationItems = nav.Items.OfType<NavigationViewItem>().Count(static item => item.Visibility is Visibility.Visible);
                     Assert.IsTrue(visibleNavigationItems > 1,
                         "Top pane should show every navigation item that fits before the overflow button would overlap the Top toggle status.");
                     NavigationViewItem? settings = FindByName<NavigationViewItem>(window, "SettingsNavigationItem");
@@ -1000,7 +1000,7 @@ namespace Fluence.Wpf.Tests
                     }
 
                     Assert.IsNotNull(trees, "DemoNav should include the Trees item.");
-                    if (trees.Visibility == Visibility.Visible)
+                    if (trees.Visibility is Visibility.Visible)
                     {
                         double treesRight = (GetVisualX(trees, nav) ?? double.MinValue) + trees.ActualWidth;
                         double overflowLeft = GetVisualX(overflowButton, nav) ?? double.MaxValue;
@@ -1278,7 +1278,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
                     Assert.AreEqual(Visibility.Visible, titleIcon.Visibility,
                         "Title icon should remain visible when title text is hidden for search clearance.");
-                    if (titleText.Visibility == Visibility.Visible)
+                    if (titleText.Visibility is Visibility.Visible)
                     {
                         Controls.TextBox? search = FindByName<Controls.TextBox>(window, "NavSearchBox");
                         Assert.IsNotNull(search, "Demo search box must be present.");
@@ -1330,7 +1330,7 @@ namespace Fluence.Wpf.Tests
 
                     WpfTextBlock? titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
-                    if (titleText.Visibility == Visibility.Visible)
+                    if (titleText.Visibility is Visibility.Visible)
                     {
                         double titleRight = (GetVisualX(titleText, window) ?? double.MinValue) + titleText.ActualWidth;
                         double searchLeft = GetVisualX(search, window) ?? double.MaxValue;
@@ -1375,7 +1375,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsNotNull(shellTitleBar, "Extended title bar should use the shared TitleBar control.");
                     WpfTextBlock? titleText = FindByName<WpfTextBlock>(shellTitleBar, "PART_TitleText");
                     Assert.IsNotNull(titleText, "Extended title bar title should exist.");
-                    if (titleText.Visibility == Visibility.Visible)
+                    if (titleText.Visibility is Visibility.Visible)
                     {
                         Controls.TextBox? setupSearch = FindByName<Controls.TextBox>(window, "NavSearchBox");
                         Assert.IsNotNull(setupSearch, "Demo search box must be present.");
@@ -1870,14 +1870,14 @@ StringComparison.Ordinal, "Rendered C# source should preserve leading indentatio
 
                     WpfTextBlock? firstBodyCell = table.Children
                         .OfType<WpfTextBlock>()
-                        .FirstOrDefault(static textBlock => Grid.GetRow(textBlock) == 1 && Grid.GetColumn(textBlock) == 0);
+                        .FirstOrDefault(static textBlock => Grid.GetRow(textBlock) is 1 && Grid.GetColumn(textBlock) is 0);
                     Assert.IsNotNull(firstBodyCell, "Typography table should include a first body row cell.");
                     Assert.AreEqual(new Thickness(24, 8, 16, 8), firstBodyCell.Margin,
                         "Typography body cells should use reduced vertical row spacing.");
 
                     WpfBorder? firstShadedRow = table.Children
                         .OfType<WpfBorder>()
-                        .FirstOrDefault(static border => Grid.GetRow(border) == 1);
+                        .FirstOrDefault(static border => Grid.GetRow(border) is 1);
                     Assert.IsNotNull(firstShadedRow, "Typography table should include shaded row backgrounds.");
                     Assert.AreEqual(new Thickness(0, 2, 0, 2), firstShadedRow.Margin,
                         "Typography shaded row background should match the compact vertical spacing.");

--- a/Fluence.Wpf.Tests/DemoSamplePageWiringTests.cs
+++ b/Fluence.Wpf.Tests/DemoSamplePageWiringTests.cs
@@ -36,9 +36,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Xml;
 using System.Xml.Linq;
-using FluenceExpander = Fluence.Wpf.Controls.Expander;
-using WpfButton = System.Windows.Controls.Button;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -73,8 +70,8 @@ namespace Fluence.Wpf.Tests
             DemoTestHost.RunOnSta(static delegate
             {
                 _ = DemoTestHost.EnsureDemoTheme();
-                WpfTextBlock demoContent = new() { Text = "Demo" };
-                WpfTextBlock outputContent = new() { Text = "Output" };
+                TextBlock demoContent = new() { Text = "Demo" };
+                TextBlock outputContent = new() { Text = "Output" };
                 CheckBox rightRailContent = new() { Content = "Option" };
                 ContentControl demoSlot = CreateSlot("DemoSampleSlot01DemoContentHost", demoContent);
                 ContentControl outputSlot = CreateSlot("DemoSampleSlot01OutputContentHost", outputContent);
@@ -138,7 +135,7 @@ namespace Fluence.Wpf.Tests
             {
                 _ = DemoTestHost.EnsureDemoTheme();
                 StackPanel root = new();
-                _ = root.Children.Add(CreateSlot("DemoSampleSlot02DemoContentHost", new WpfTextBlock()));
+                _ = root.Children.Add(CreateSlot("DemoSampleSlot02DemoContentHost", new TextBlock()));
                 _ = root.Children.Add(new DemoSampleControl());
 
                 AssertThrowsInvalidOperation(
@@ -153,7 +150,7 @@ namespace Fluence.Wpf.Tests
             {
                 _ = DemoTestHost.EnsureDemoTheme();
                 StackPanel root = new();
-                _ = root.Children.Add(CreateSlot("DemoSampleSlot00DemoContentHost", new WpfTextBlock()));
+                _ = root.Children.Add(CreateSlot("DemoSampleSlot00DemoContentHost", new TextBlock()));
                 _ = root.Children.Add(new DemoSampleControl());
 
                 AssertThrowsInvalidOperation(
@@ -168,8 +165,8 @@ namespace Fluence.Wpf.Tests
             {
                 _ = DemoTestHost.EnsureDemoTheme();
                 StackPanel root = new();
-                _ = root.Children.Add(CreateSlot("DemoSampleSlot01DemoContentHost", new WpfTextBlock()));
-                _ = root.Children.Add(CreateSlot("DemoSampleSlot01DemoContentHost", new WpfTextBlock()));
+                _ = root.Children.Add(CreateSlot("DemoSampleSlot01DemoContentHost", new TextBlock()));
+                _ = root.Children.Add(CreateSlot("DemoSampleSlot01DemoContentHost", new TextBlock()));
                 _ = root.Children.Add(new DemoSampleControl());
 
                 AssertThrowsInvalidOperation(
@@ -185,13 +182,13 @@ namespace Fluence.Wpf.Tests
                 _ = DemoTestHost.EnsureDemoTheme();
                 DemoSampleControl sample = new()
                 {
-                    DemoContent = new WpfTextBlock { Text = "Body" },
+                    DemoContent = new TextBlock { Text = "Body" },
                     XamlSource = "<Grid />",
                 };
                 Window window = DemoTestHost.CreateHostWindow(sample);
                 try
                 {
-                    FluenceExpander? expander = DemoTestHost.FindByName<FluenceExpander>(sample, "SourceExpander");
+                    Controls.Expander? expander = DemoTestHost.FindByName<Controls.Expander>(sample, "SourceExpander");
                     Assert.IsNotNull(expander, "Source expander should exist.");
                     expander.IsExpanded = true;
                     DemoTestHost.Drain(window.Dispatcher);
@@ -313,7 +310,7 @@ namespace Fluence.Wpf.Tests
             Assert.IsNotNull(tabs, "Source tabs should exist.");
             Assert.AreEqual(1, tabs.Items.Count, "XAML-only sample should expose one source tab.");
             TabItem tab = (TabItem)tabs.Items[0];
-            WpfButton? copy = DemoTestHost.FindByName<WpfButton>(tab.Content as DependencyObject, "CopySourceButton");
+            Button? copy = DemoTestHost.FindByName<Button>(tab.Content as DependencyObject, "CopySourceButton");
             Assert.IsNotNull(copy, "Source tab should expose the copy button.");
             Assert.AreEqual(expectedSource, copy.Tag as string);
         }

--- a/Fluence.Wpf.Tests/DemoSamplePageWiringTests.cs
+++ b/Fluence.Wpf.Tests/DemoSamplePageWiringTests.cs
@@ -225,7 +225,7 @@ namespace Fluence.Wpf.Tests
                     {
                         List<DemoSampleControl> samples = [.. DemoTestHost.FindVisualChildren<DemoSampleControl>(page)];
                         Assert.IsTrue(samples.Count > 0, "Page should expose DemoSampleControl samples: " + page.GetType().Name);
-                        foreach (DemoSampleControl sample in samples.Where(static sample => sample.Visibility == Visibility.Visible))
+                        foreach (DemoSampleControl sample in samples.Where(static sample => sample.Visibility is Visibility.Visible))
                         {
                             Assert.IsFalse(string.IsNullOrWhiteSpace(sample.XamlSource),
                                 "Visible DemoSampleControl should expose XAML source: " + page.GetType().Name);
@@ -329,7 +329,7 @@ namespace Fluence.Wpf.Tests
                 try
                 {
                     samples.AddRange(DemoTestHost.FindVisualChildren<DemoSampleControl>(page)
-                        .Where(static sample => sample.Visibility == Visibility.Visible));
+                        .Where(static sample => sample.Visibility is Visibility.Visible));
                 }
                 finally
                 {
@@ -437,7 +437,7 @@ namespace Fluence.Wpf.Tests
             int index = text.IndexOf(word, StringComparison.Ordinal);
             while (index >= 0)
             {
-                bool startsOnBoundary = index == 0 || !IsWordCharacter(text[index - 1]);
+                bool startsOnBoundary = index is 0 || !IsWordCharacter(text[index - 1]);
                 int end = index + word.Length;
                 bool endsOnBoundary = end == text.Length || !IsWordCharacter(text[end]);
                 if (startsOnBoundary && endsOnBoundary)

--- a/Fluence.Wpf.Tests/DictionaryStabilityTests.cs
+++ b/Fluence.Wpf.Tests/DictionaryStabilityTests.cs
@@ -205,12 +205,12 @@ namespace Fluence.Wpf.Tests
 
                 Uri typographySource = dictionaries[1].Source;
                 Assert.IsNotNull(typographySource, "Typography slot [1] should have a Source URI.");
-                Assert.IsTrue(typographySource.OriginalString.IndexOf("Typography", StringComparison.OrdinalIgnoreCase) >= 0,
+                Assert.IsTrue(typographySource.OriginalString.Contains("Typography", StringComparison.OrdinalIgnoreCase),
                     "Slot [1] Source should be Typography.xaml, but was " + typographySource.OriginalString);
 
                 Uri genericSource = dictionaries[2].Source;
                 Assert.IsNotNull(genericSource, "Generic slot [2] should have a Source URI.");
-                Assert.IsTrue(genericSource.OriginalString.IndexOf("Generic", StringComparison.OrdinalIgnoreCase) >= 0,
+                Assert.IsTrue(genericSource.OriginalString.Contains("Generic", StringComparison.OrdinalIgnoreCase),
                     "Slot [2] Source should be Generic.xaml, but was " + genericSource.OriginalString);
             });
         }

--- a/Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj
+++ b/Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TestTfmsInParallel>false</TestTfmsInParallel>
-    <NoWarn>$(NoWarn);CA1031;CA1305;CA1707;CA1861;CA2249;CA2263;CS1591;IDE0330;VSTHRD001</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA1707;CA2263;CS1591;VSTHRD001;MA0045</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluence.Wpf.Tests/FluenceWindowHardenTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowHardenTests.cs
@@ -360,7 +360,8 @@ namespace Fluence.Wpf.Tests
         {
             WpfTestSta.Dispatcher?.Invoke(
                 new Action(static () => { }),
-                DispatcherPriority.ContextIdle);
+                DispatcherPriority.ContextIdle,
+                default);
         }
 
         [TestMethod]

--- a/Fluence.Wpf.Tests/FluenceWindowSizeToContentTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowSizeToContentTests.cs
@@ -32,12 +32,11 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
-using FluenceWindow = Fluence.Wpf.Controls.FluenceWindow;
 
 namespace Fluence.Wpf.Tests
 {
     /// <summary>
-    /// Regression tests for the SizeToContent double-border fix in <see cref="FluenceWindow"/>.
+    /// Regression tests for the SizeToContent double-border fix in <see cref="Controls.FluenceWindow"/>.
     /// A <see cref="Window"/> with an active <see cref="Window.SizeToContent"/> sizes its HWND to the
     /// latest content-desired size, but the template root <c>Border</c> (the accent-bordered window
     /// chrome) was left arranged one layout pass behind the realised client area, so it floated
@@ -87,7 +86,7 @@ namespace Fluence.Wpf.Tests
             ApplicationThemeManager.Apply(ApplicationTheme.Dark, BackdropType.None, updateAccent: true);
         }
 
-        private static Border FindWindowBorder(FluenceWindow window)
+        private static Border FindWindowBorder(Controls.FluenceWindow window)
         {
             Border? border = WpfTestSta
                 .FindVisualDescendants<Border>(window)
@@ -121,7 +120,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = WpfTestSta.EnsureApplication();
                 ResetAndApply(app);
 
-                FluenceWindow window = new()
+                Controls.FluenceWindow window = new()
                 {
                     Title = "SizeToContent fill",
                     SystemBackdropType = BackdropType.None,
@@ -173,7 +172,7 @@ namespace Fluence.Wpf.Tests
                 ResetAndApply(app);
 
                 StackPanel panel = BuildContent();
-                FluenceWindow window = new()
+                Controls.FluenceWindow window = new()
                 {
                     Title = "SizeToContent grow",
                     SystemBackdropType = BackdropType.None,
@@ -228,7 +227,7 @@ namespace Fluence.Wpf.Tests
                 Application? app = WpfTestSta.EnsureApplication();
                 ResetAndApply(app);
 
-                FluenceWindow window = new()
+                Controls.FluenceWindow window = new()
                 {
                     Title = "Fixed size",
                     SystemBackdropType = BackdropType.None,

--- a/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
@@ -576,13 +576,13 @@ namespace Fluence.Wpf.Tests
 
             string xaml = System.IO.File.ReadAllText(xamlPath);
             Assert.IsTrue(
-                xaml.IndexOf("MinimizeWindowCommand", StringComparison.Ordinal) >= 0,
+                xaml.Contains("MinimizeWindowCommand", StringComparison.Ordinal),
                 "Minimize button should bind MinimizeWindowCommand.");
             Assert.IsTrue(
-                xaml.IndexOf("MaximizeWindowCommand", StringComparison.Ordinal) >= 0,
+                xaml.Contains("MaximizeWindowCommand", StringComparison.Ordinal),
                 "Maximize button should bind MaximizeWindowCommand.");
             Assert.IsTrue(
-                xaml.IndexOf("CloseWindowCommand", StringComparison.Ordinal) >= 0,
+                xaml.Contains("CloseWindowCommand", StringComparison.Ordinal),
                 "Close button should bind CloseWindowCommand.");
         }
 

--- a/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
@@ -130,7 +130,7 @@ namespace Fluence.Wpf.Tests
                         ShowInTaskbar = false,
                     };
                     window.Show();
-                    window.Dispatcher.Invoke(() => { }, DispatcherPriority.Loaded);
+                    window.Dispatcher.Invoke(() => { }, DispatcherPriority.Loaded, default);
                     testBody(window);
                 }
                 finally
@@ -642,7 +642,7 @@ namespace Fluence.Wpf.Tests
             RunWithShownWindow(static w =>
             {
                 w.IsMaximizeButtonVisible = Visibility.Hidden;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 System.Windows.Controls.Button? btn = GetCaptionButtonField(w, "_maximizeButton");
                 Assert.IsNotNull(btn);
@@ -661,7 +661,7 @@ namespace Fluence.Wpf.Tests
             RunWithShownWindow(static w =>
             {
                 w.IsMaximizable = false;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 System.Windows.Controls.Button? btn = GetCaptionButtonField(w, "_maximizeButton");
                 Assert.IsNotNull(btn);
@@ -772,7 +772,7 @@ namespace Fluence.Wpf.Tests
                     new IntPtr(NativeConstants.HTMAXBUTTON),
                     IntPtr.Zero,
                     out bool handled);
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.IsTrue(handled,
                     "WM_NCLBUTTONUP/HTMAXBUTTON should be handled by FluenceWindow.");
@@ -789,7 +789,7 @@ namespace Fluence.Wpf.Tests
                     new IntPtr(NativeConstants.HTMAXBUTTON),
                     IntPtr.Zero,
                     out handled);
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.IsTrue(handled,
                     "Second WM_NCLBUTTONUP/HTMAXBUTTON should be handled by FluenceWindow.");
@@ -836,7 +836,7 @@ namespace Fluence.Wpf.Tests
                     BindingFlags.Instance | BindingFlags.NonPublic);
                 Assert.IsNotNull(setSnapHover, "SetSnapHover must exist for the snap-hover token test.");
                 _ = setSnapHover.Invoke(w, [max]);
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreSame(expectedBackground, max.Background,
                     "Snap hover must set the maximize button Background to SubtleFillColorSecondaryBrush, matching the WindowButtonStyle PointerOver state.");
@@ -852,7 +852,7 @@ namespace Fluence.Wpf.Tests
                     BindingFlags.Instance | BindingFlags.NonPublic);
                 Assert.IsNotNull(clearSnapHover, "ClearSnapHover must exist for the snap-hover token test.");
                 _ = clearSnapHover.Invoke(w, parameters: null);
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(DependencyProperty.UnsetValue, max.ReadLocalValue(System.Windows.Controls.Control.BackgroundProperty),
                     "ClearSnapHover must ClearValue the Background local value so the style/template default applies again.");
@@ -875,7 +875,7 @@ namespace Fluence.Wpf.Tests
                 // DialogAllowMinimize is honoured (IsMinimizeButtonVisible=Visibility.Visible).
                 w.IsMinimizeButtonVisible = Visibility.Collapsed;
                 w.ResizeMode = ResizeMode.NoResize;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 System.Windows.Controls.Button? btn = GetCaptionButtonField(w, "_minimizeButton");
                 Assert.IsNotNull(btn);
@@ -884,7 +884,7 @@ namespace Fluence.Wpf.Tests
 
                 w.IsMinimizeButtonVisible = Visibility.Visible;
                 w.IsMinimizable = true;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(Visibility.Visible, btn.Visibility,
                     "Explicit flip Collapsed->Visible must override the NoResize-derived Collapsed baseline.");
@@ -900,7 +900,7 @@ namespace Fluence.Wpf.Tests
             {
                 w.ResizeMode = ResizeMode.CanResize;
                 w.IsMinimizeButtonVisible = Visibility.Collapsed;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 System.Windows.Controls.Button? btn = GetCaptionButtonField(w, "_minimizeButton");
                 Assert.IsNotNull(btn);
@@ -918,7 +918,7 @@ namespace Fluence.Wpf.Tests
             {
                 w.IsMaximizeButtonVisible = Visibility.Collapsed;
                 w.ResizeMode = ResizeMode.NoResize;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 System.Windows.Controls.Button? max = GetCaptionButtonField(w, "_maximizeButton");
                 Assert.IsNotNull(max);
@@ -927,7 +927,7 @@ namespace Fluence.Wpf.Tests
 
                 w.IsMaximizeButtonVisible = Visibility.Visible;
                 w.IsMaximizable = true;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(Visibility.Visible, max.Visibility,
                     "Explicit flip Collapsed->Visible must override the NoResize-derived Collapsed baseline.");
@@ -943,7 +943,7 @@ namespace Fluence.Wpf.Tests
             RunWithShownWindow(static w =>
             {
                 w.IsMaximizeButtonVisible = Visibility.Hidden;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 System.Windows.Controls.Button? max = GetCaptionButtonField(w, "_maximizeButton");
                 System.Windows.Controls.Button? restore = GetCaptionButtonField(w, "_restoreButton");
@@ -953,7 +953,7 @@ namespace Fluence.Wpf.Tests
                 Assert.IsFalse(restore?.IsEnabled ?? false);
 
                 w.WindowState = WindowState.Maximized;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(Visibility.Collapsed, max?.Visibility);
                 Assert.AreEqual(Visibility.Hidden, restore?.Visibility);
@@ -999,7 +999,7 @@ namespace Fluence.Wpf.Tests
                     w.IsMinimizeButtonVisible = value;
                     w.IsMaximizeButtonVisible = value;
                     w.IsCloseButtonVisible = value;
-                    w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                    w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                     Assert.AreEqual(value, minimize.Visibility);
                     Assert.AreEqual(value, close.Visibility);
@@ -1112,7 +1112,7 @@ modifiers: null);
                 Assert.AreEqual(Visibility.Visible, closeBtn?.Visibility);
 
                 w.ResizeMode = ResizeMode.NoResize;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(Visibility.Collapsed, minBtn?.Visibility,
                     "Pre-existing contract: untouched DPs hide min/max when ResizeMode=NoResize.");
@@ -1141,7 +1141,7 @@ modifiers: null);
                     "OnMinimizeWindow",
                     CreateExecutedArgs(SystemCommands.MinimizeWindowCommand));
 
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(WindowState.Minimized, w.WindowState,
                     "OnMinimizeWindow must drive WindowState=Minimized even when HideAllWindowButtons has stripped WS_SYSMENU.");
@@ -1161,7 +1161,7 @@ modifiers: null);
                     "OnMaximizeWindow",
                     CreateExecutedArgs(SystemCommands.MaximizeWindowCommand));
 
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(WindowState.Maximized, w.WindowState,
                     "OnMaximizeWindow must drive WindowState=Maximized even when HideAllWindowButtons has stripped WS_SYSMENU.");
@@ -1174,7 +1174,7 @@ modifiers: null);
             RunWithShownWindow(static w =>
             {
                 w.WindowState = WindowState.Maximized;
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
                 Assert.AreEqual(WindowState.Maximized, w.WindowState,
                     "Precondition: test setup failed to drive the window to Maximized state.");
 
@@ -1183,7 +1183,7 @@ modifiers: null);
                     "OnRestoreWindow",
                     CreateExecutedArgs(SystemCommands.RestoreWindowCommand));
 
-                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                w.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
 
                 Assert.AreEqual(WindowState.Normal, w.WindowState,
                     "OnRestoreWindow must drive WindowState=Normal regardless of sysmenu/style gating.");
@@ -1226,14 +1226,14 @@ modifiers: null);
                     };
 
                     window.Show();
-                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.Loaded);
+                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.Loaded, default);
 
                     // Flip visibility after Show() to mirror PSADT's IsMinimizeButtonVisible=Visibility.Visible.
                     window.IsMinimizeButtonVisible = Visibility.Visible;
                     window.IsMinimizable = true;
-                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
+                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
                     CommandManager.InvalidateRequerySuggested();
-                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.ApplicationIdle);
+                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.ApplicationIdle, default);
 
                     System.Windows.Controls.Button? minBtn = GetCaptionButtonField(window, "_minimizeButton");
                     Assert.IsNotNull(minBtn, "Minimize template part must exist after Show.");
@@ -1253,8 +1253,8 @@ modifiers: null);
                     // on its own DataContext (the button is the command target, the window is
                     // the CommandBinding host via routed-command bubbling).
                     SystemCommands.MinimizeWindowCommand.Execute(parameter: null, minBtn);
-                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render);
-                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.ApplicationIdle);
+                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.Render, default);
+                    window.Dispatcher.Invoke(static () => { }, DispatcherPriority.ApplicationIdle, default);
 
                     Assert.AreEqual(WindowState.Minimized, window.WindowState,
                         "PSADT flow: SystemCommands.MinimizeWindowCommand.Execute must end with WindowState=Minimized even when Topmost=True + ResizeMode=NoResize + HideAllWindowButtons has stripped the sysmenu.");
@@ -1518,9 +1518,9 @@ modifiers: null);
                     };
 
                     window.Show();
-                    window.Dispatcher.Invoke(() => { }, DispatcherPriority.Loaded);
+                    window.Dispatcher.Invoke(() => { }, DispatcherPriority.Loaded, default);
                     window.UpdateLayout();
-                    window.Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
+                    window.Dispatcher.Invoke(() => { }, DispatcherPriority.Render, default);
 
                     foreach (string? fieldName in new[] { "_minimizeButton", "_maximizeButton", "_closeButton" })
                     {

--- a/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
+++ b/Fluence.Wpf.Tests/FluenceWindowTitleBarTests.cs
@@ -540,7 +540,7 @@ namespace Fluence.Wpf.Tests
 
                     for (int i = 0; i < 5; i++)
                     {
-                        ApplicationTheme theme = i % 2 == 0 ? ApplicationTheme.Dark : ApplicationTheme.Light;
+                        ApplicationTheme theme = i % 2 is 0 ? ApplicationTheme.Dark : ApplicationTheme.Light;
                         ApplicationThemeManager.Apply(theme, BackdropType.None, updateAccent: true);
                     }
 
@@ -1006,7 +1006,7 @@ namespace Fluence.Wpf.Tests
                     Assert.AreEqual(value, maximize.Visibility);
                     Assert.AreEqual(Visibility.Collapsed, restore.Visibility);
 
-                    bool enabled = value == Visibility.Visible;
+                    bool enabled = value is Visibility.Visible;
                     Assert.AreEqual(enabled, minimize.IsEnabled);
                     Assert.AreEqual(enabled, maximize.IsEnabled);
                     Assert.AreEqual(enabled, close.IsEnabled);
@@ -1367,7 +1367,7 @@ modifiers: null);
                 }
                 finally
                 {
-                    if (window?.IsVisible == true)
+                    if ((window?.IsVisible) is true)
                     {
                         window.Close();
                     }

--- a/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
+++ b/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
@@ -251,7 +251,7 @@ namespace Fluence.Wpf.Tests
         }
 
         /// <summary>
-        /// Captures the gallery shell (<see cref="DemoMainWindow"/>) at <paramref name="route"/>
+        /// Captures the gallery shell (<see cref="Demo.MainWindow"/>) at <paramref name="route"/>
         /// with the navigation pane forced to <paramref name="paneMode"/>, writing
         /// <c>{outputName}-{themeSlug}.png</c>.
         /// </summary>

--- a/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
+++ b/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
@@ -282,7 +282,7 @@ namespace Fluence.Wpf.Tests
                 if (window.DemoNav is not null)
                 {
                     window.DemoNav.PaneDisplayMode = paneMode;
-                    window.DemoNav.IsPaneOpen = paneMode == NavigationViewPaneDisplayMode.Left;
+                    window.DemoNav.IsPaneOpen = paneMode is NavigationViewPaneDisplayMode.Left;
                 }
 
                 window.NavigateTo(route);

--- a/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
+++ b/Fluence.Wpf.Tests/GalleryScreenshotHarness.cs
@@ -36,12 +36,6 @@ using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
-using DemoMainWindow = Fluence.Wpf.Demo.MainWindow;
-using FluenceWindow = Fluence.Wpf.Controls.FluenceWindow;
-#if NET10_0_OR_GREATER
-using MvvmMainWindow = Fluence.Wpf.Demo.Mvvm.MainWindow;
-using MvvmMainViewModel = Fluence.Wpf.Demo.Mvvm.ViewModels.MainViewModel;
-#endif
 
 namespace Fluence.Wpf.Tests
 {
@@ -210,7 +204,7 @@ namespace Fluence.Wpf.Tests
             window.SizeToContent = SizeToContent.Manual;
             window.SetResourceReference(Control.BackgroundProperty, "SolidBackgroundFillColorBaseBrush");
 
-            if (window is FluenceWindow fluenceWindow)
+            if (window is Controls.FluenceWindow fluenceWindow)
             {
                 fluenceWindow.SystemBackdropType = BackdropType.None;
             }
@@ -271,10 +265,10 @@ namespace Fluence.Wpf.Tests
         {
             _ = ResetApplication(theme, includeDemoSharedStyles: true);
 
-            DemoMainWindow? window = null;
+            Demo.MainWindow? window = null;
             try
             {
-                window = new DemoMainWindow();
+                window = new Demo.MainWindow();
                 PrepareCaptureWindow(window, GalleryCaptureWidth, GalleryCaptureHeight);
                 window.Show();
                 DrainDispatcher(window.Dispatcher);
@@ -375,7 +369,7 @@ namespace Fluence.Wpf.Tests
         }
 
 #if NET10_0_OR_GREATER
-        private static void AddScreenshotTask(MvvmMainViewModel viewModel, string title, bool isCompleted)
+        private static void AddScreenshotTask(Demo.Mvvm.ViewModels.MainViewModel viewModel, string title, bool isCompleted)
         {
             viewModel.NewTaskText = title;
             if (viewModel.AddCommand.CanExecute(parameter: null))
@@ -389,9 +383,9 @@ namespace Fluence.Wpf.Tests
             }
         }
 
-        private static void SeedMvvmScreenshotData(MvvmMainWindow window)
+        private static void SeedMvvmScreenshotData(Demo.Mvvm.MainWindow window)
         {
-            if (window.DataContext is not MvvmMainViewModel viewModel)
+            if (window.DataContext is not Demo.Mvvm.ViewModels.MainViewModel viewModel)
             {
                 return;
             }
@@ -406,10 +400,10 @@ namespace Fluence.Wpf.Tests
         {
             _ = ResetApplication(theme, includeDemoSharedStyles: false);
 
-            MvvmMainWindow? window = null;
+            Demo.Mvvm.MainWindow? window = null;
             try
             {
-                window = new MvvmMainWindow();
+                window = new Demo.Mvvm.MainWindow();
                 SeedMvvmScreenshotData(window);
                 PrepareCaptureWindow(window, AppCaptureWidth, AppCaptureHeight);
                 string fullPath = Path.Combine(outputDirectory, Invariant("mvvm-{0}.png", themeSlug));

--- a/Fluence.Wpf.Tests/ImmersiveColorSetProbe.cs
+++ b/Fluence.Wpf.Tests/ImmersiveColorSetProbe.cs
@@ -161,7 +161,7 @@ namespace Fluence.Wpf.Tests
             byte g = (byte)((nativeColor >> 8) & 0xFF);
             byte b = (byte)((nativeColor >> 16) & 0xFF);
             byte a = (byte)((nativeColor >> 24) & 0xFF);
-            return Color.FromArgb(a == 0 ? (byte)0xFF : a, r, g, b);
+            return Color.FromArgb(a is 0 ? (byte)0xFF : a, r, g, b);
         }
 
         private static int Pack(Color c)

--- a/Fluence.Wpf.Tests/ListViewIsItemSelectableTests.cs
+++ b/Fluence.Wpf.Tests/ListViewIsItemSelectableTests.cs
@@ -32,8 +32,6 @@ using System.Collections.ObjectModel;
 using System.Runtime.ExceptionServices;
 using System.Windows;
 using System.Windows.Threading;
-using FluenceListView = Fluence.Wpf.Controls.ListView;
-using WpfListViewItem = System.Windows.Controls.ListViewItem;
 
 namespace Fluence.Wpf.Tests
 {
@@ -94,7 +92,7 @@ namespace Fluence.Wpf.Tests
         {
             RunOnFreshStaThread(static () =>
             {
-                FluenceListView lv = new();
+                Controls.ListView lv = new();
                 Assert.IsTrue(lv.IsItemSelectable);
             });
         }
@@ -108,7 +106,7 @@ namespace Fluence.Wpf.Tests
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: true);
                 Window window = new();
-                FluenceListView lv = new() { Width = 260, Height = 120 };
+                Controls.ListView lv = new() { Width = 260, Height = 120 };
                 _ = lv.Items.Add("a");
                 _ = lv.Items.Add("b");
 
@@ -146,7 +144,7 @@ namespace Fluence.Wpf.Tests
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: true);
                 Window window = new();
-                FluenceListView lv = new()
+                Controls.ListView lv = new()
                 {
                     Width = 260,
                     Height = 120,
@@ -185,7 +183,7 @@ namespace Fluence.Wpf.Tests
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: true);
                 Window window = new();
-                FluenceListView lv = new()
+                Controls.ListView lv = new()
                 {
                     Width = 260,
                     Height = 120,
@@ -200,10 +198,10 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfListViewItem? container = lv.ItemContainerGenerator.ContainerFromIndex(0) as WpfListViewItem;
+                    System.Windows.Controls.ListViewItem? container = lv.ItemContainerGenerator.ContainerFromIndex(0) as System.Windows.Controls.ListViewItem;
                     Assert.IsNotNull(container, "Item container should be generated.");
                     Assert.IsFalse(container.Focusable);
-                    Assert.IsFalse(FluenceListView.GetParentIsItemSelectable(container));
+                    Assert.IsFalse(Controls.ListView.GetParentIsItemSelectable(container));
                 }
                 finally
                 {
@@ -225,7 +223,7 @@ namespace Fluence.Wpf.Tests
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: true);
                 Window window = new();
-                FluenceListView lv = new()
+                Controls.ListView lv = new()
                 {
                     Width = 260,
                     Height = 120,
@@ -240,10 +238,10 @@ namespace Fluence.Wpf.Tests
                     DrainDispatcher(window.Dispatcher);
                     window.UpdateLayout();
 
-                    WpfListViewItem? container = lv.ItemContainerGenerator.ContainerFromIndex(0) as WpfListViewItem;
+                    System.Windows.Controls.ListViewItem? container = lv.ItemContainerGenerator.ContainerFromIndex(0) as System.Windows.Controls.ListViewItem;
                     Assert.IsNotNull(container);
                     Assert.IsTrue(container.Focusable);
-                    Assert.IsTrue(FluenceListView.GetParentIsItemSelectable(container));
+                    Assert.IsTrue(Controls.ListView.GetParentIsItemSelectable(container));
                 }
                 finally
                 {
@@ -261,7 +259,7 @@ namespace Fluence.Wpf.Tests
         {
             RunOnFreshStaThread(static () =>
             {
-                FluenceListView lv = new() { IsItemSelectable = false, ItemAnimationsEnabled = true };
+                Controls.ListView lv = new() { IsItemSelectable = false, ItemAnimationsEnabled = true };
                 Assert.IsFalse(lv.IsItemSelectable);
                 Assert.IsTrue(lv.ItemAnimationsEnabled);
 

--- a/Fluence.Wpf.Tests/SplitButtonTests.cs
+++ b/Fluence.Wpf.Tests/SplitButtonTests.cs
@@ -65,7 +65,7 @@ namespace Fluence.Wpf.Tests
 
         private static void Drain(Dispatcher dispatcher)
         {
-            dispatcher.Invoke(new Action(static delegate { }), DispatcherPriority.ApplicationIdle);
+            dispatcher.Invoke(new Action(static delegate { }), DispatcherPriority.ApplicationIdle, default);
         }
 
         private static void MergeGeneric(Application? application)

--- a/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
+++ b/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
@@ -162,7 +162,7 @@ namespace Fluence.Wpf.Tests
             string[] offenders =
             [
                 .. EnumerateProductionSources(productionRoots)
-                    .Where(path => !string.Equals(GetRepoRelativePath(path), allowedPath, StringComparison.OrdinalIgnoreCase) && File.ReadAllText(path).IndexOf("SnapsToDevicePixels", StringComparison.Ordinal) >= 0)
+                    .Where(path => !string.Equals(GetRepoRelativePath(path), allowedPath, StringComparison.OrdinalIgnoreCase) && File.ReadAllText(path).Contains("SnapsToDevicePixels", StringComparison.Ordinal))
                     .Select(GetRepoRelativePath),
             ];
 
@@ -294,8 +294,8 @@ namespace Fluence.Wpf.Tests
         {
             string normalized = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             string separator = Path.DirectorySeparatorChar.ToString();
-            return normalized.IndexOf(separator + "bin" + separator, StringComparison.OrdinalIgnoreCase) >= 0 ||
-                normalized.IndexOf(separator + "obj" + separator, StringComparison.OrdinalIgnoreCase) >= 0;
+            return normalized.Contains(separator + "bin" + separator, StringComparison.OrdinalIgnoreCase) ||
+                normalized.Contains(separator + "obj" + separator, StringComparison.OrdinalIgnoreCase);
         }
 
         private static IEnumerable<string> FindBannedFragments(string path, IEnumerable<string> bannedFragments)
@@ -303,7 +303,7 @@ namespace Fluence.Wpf.Tests
             string source = File.ReadAllText(path);
             foreach (string bannedFragment in bannedFragments)
             {
-                if (source.IndexOf(bannedFragment, StringComparison.Ordinal) >= 0)
+                if (source.Contains(bannedFragment, StringComparison.Ordinal))
                 {
                     yield return GetRepoRelativePath(path) + ": " + bannedFragment;
                 }

--- a/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
+++ b/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
@@ -35,8 +35,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using WpfBorder = System.Windows.Controls.Border;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -84,7 +82,7 @@ namespace Fluence.Wpf.Tests
                 Application? application = WpfTestSta.EnsureApplication();
                 ResetApplication(application);
 
-                WpfBorder child = new();
+                System.Windows.Controls.Border child = new();
                 FluenceWindow window = new()
                 {
                     Width = 320,
@@ -199,7 +197,7 @@ namespace Fluence.Wpf.Tests
                 Application? application = WpfTestSta.EnsureApplication();
                 ResetApplication(application);
 
-                WpfTextBlock textBlock = new();
+                System.Windows.Controls.TextBlock textBlock = new();
                 textBlock.SetTypography(FluentTypography.Title);
 
                 Assert.AreSame(
@@ -218,7 +216,7 @@ namespace Fluence.Wpf.Tests
         {
             WpfTestSta.Invoke(static () =>
             {
-                WpfTextBlock textBlock = new();
+                System.Windows.Controls.TextBlock textBlock = new();
                 textBlock.SetTypography(FluentTypography.Body);
 
                 FontFamily fontFamily = new("Arial");
@@ -256,7 +254,7 @@ namespace Fluence.Wpf.Tests
             Style? style = application?.TryFindResource(styleKey) as Style;
             Assert.IsNotNull(style, styleKey + " should resolve.");
 
-            WpfTextBlock textBlock = new()
+            System.Windows.Controls.TextBlock textBlock = new()
             {
                 Style = style,
             };

--- a/Fluence.Wpf.Tests/ThemeTestHelpersTests.cs
+++ b/Fluence.Wpf.Tests/ThemeTestHelpersTests.cs
@@ -69,7 +69,7 @@ namespace Fluence.Wpf.Tests
                     Controls.Border panel = new() { Width = 10, Height = 10 };
                     window.Content = panel;
                     window.Show();
-                    window.Dispatcher.Invoke(static () => { }, System.Windows.Threading.DispatcherPriority.Loaded);
+                    window.Dispatcher.Invoke(static () => { }, System.Windows.Threading.DispatcherPriority.Loaded, default);
                     DpiScale dpi = System.Windows.Media.VisualTreeHelper.GetDpi(panel);
                     Assert.IsTrue(dpi.PixelsPerDip > 0, "DpiScale.PixelsPerDip should be positive.");
                 }

--- a/Fluence.Wpf.Tests/Theming/ThemeParityTests.cs
+++ b/Fluence.Wpf.Tests/Theming/ThemeParityTests.cs
@@ -134,8 +134,8 @@ namespace Fluence.Wpf.Tests.Theming
                     // reason as the SystemColor* aliases above. Their highlight binding is covered
                     // hermetically by HighContrast_HighlightDerivedBrushes_BindToLiveSystemHighlight
                     // and HighContrast_HighlightTextDerivedBrushes_BindToLiveSystemHighlightText.
-                    if (theme == ApplicationTheme.HighContrast
-                        && (HighContrastHighlightDerivedBrushKeys.Contains(ks)
+                    if (theme is ApplicationTheme.HighContrast
+                            && (HighContrastHighlightDerivedBrushKeys.Contains(ks)
                             || HighContrastHighlightTextDerivedBrushKeys.Contains(ks)))
                     {
                         continue;

--- a/Fluence.Wpf.Tests/TitleBarTests.cs
+++ b/Fluence.Wpf.Tests/TitleBarTests.cs
@@ -38,9 +38,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shell;
 using System.Windows.Threading;
-using Fluent = Fluence.Wpf.Controls;
-using WpfButton = System.Windows.Controls.Button;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -65,7 +62,7 @@ namespace Fluence.Wpf.Tests
             RunWithTitleBar(
                 static delegate
                 {
-                    return new Fluent.TitleBar
+                    return new Controls.TitleBar
                     {
                         Title = "Fluence",
                         IsBackButtonVisible = true,
@@ -74,8 +71,8 @@ namespace Fluence.Wpf.Tests
                 },
                 static titleBar =>
                 {
-                    WpfButton backButton = GetTemplateButton(titleBar, "PART_BackButton");
-                    WpfButton paneToggleButton = GetTemplateButton(titleBar, "PART_PaneToggleButton");
+                    System.Windows.Controls.Button backButton = GetTemplateButton(titleBar, "PART_BackButton");
+                    System.Windows.Controls.Button paneToggleButton = GetTemplateButton(titleBar, "PART_PaneToggleButton");
 
                     Assert.AreEqual(Visibility.Visible, backButton.Visibility,
                         "PART_BackButton must be visible when IsBackButtonVisible is true.");
@@ -94,7 +91,7 @@ namespace Fluence.Wpf.Tests
             RunWithTitleBar(
                 static delegate
                 {
-                    return new Fluent.TitleBar
+                    return new Controls.TitleBar
                     {
                         Title = "Fluence",
                         IsBackButtonVisible = true,
@@ -103,8 +100,8 @@ namespace Fluence.Wpf.Tests
                 },
                 static titleBar =>
                 {
-                    WpfButton backButton = GetTemplateButton(titleBar, "PART_BackButton");
-                    WpfButton paneToggleButton = GetTemplateButton(titleBar, "PART_PaneToggleButton");
+                    System.Windows.Controls.Button backButton = GetTemplateButton(titleBar, "PART_BackButton");
+                    System.Windows.Controls.Button paneToggleButton = GetTemplateButton(titleBar, "PART_PaneToggleButton");
 
                     Assert.AreEqual(36.0, backButton.ActualWidth, 0.5,
                         "The title-bar back button should use a smaller slot than the pane toggle.");
@@ -115,7 +112,7 @@ namespace Fluence.Wpf.Tests
                     Assert.AreEqual(36.0, paneToggleButton.ActualHeight, 0.5,
                         "The title-bar pane toggle should keep the compact title-bar glyph height.");
 
-                    WpfTextBlock? backGlyph = FindVisualChild<WpfTextBlock>(backButton);
+                    System.Windows.Controls.TextBlock? backGlyph = FindVisualChild<System.Windows.Controls.TextBlock>(backButton);
                     Assert.IsNotNull(backGlyph, "Back button should render a glyph text block.");
                     Assert.AreEqual(16.0, backGlyph.ActualWidth, 0.5,
                         "Back glyph should occupy a 16px visual box.");
@@ -135,7 +132,7 @@ namespace Fluence.Wpf.Tests
             RunWithTitleBar(
                 delegate
                 {
-                    return new Fluent.TitleBar
+                    return new Controls.TitleBar
                     {
                         IsPaneToggleButtonVisible = true,
                         PaneToggleCommand = command,
@@ -173,7 +170,7 @@ namespace Fluence.Wpf.Tests
             RunWithTitleBar(
                 delegate
                 {
-                    return new Fluent.TitleBar
+                    return new Controls.TitleBar
                     {
                         BackCommand = command,
                         BackCommandParameter = parameter,
@@ -181,7 +178,7 @@ namespace Fluence.Wpf.Tests
                 },
                 titleBar =>
                 {
-                    WpfButton backButton = GetTemplateButton(titleBar, "PART_BackButton");
+                    System.Windows.Controls.Button backButton = GetTemplateButton(titleBar, "PART_BackButton");
                     Assert.AreEqual(Visibility.Collapsed, backButton.Visibility,
                         "PART_BackButton must default to collapsed.");
 
@@ -213,7 +210,7 @@ namespace Fluence.Wpf.Tests
             RunWithTitleBar(
                 delegate
                 {
-                    return new Fluent.TitleBar
+                    return new Controls.TitleBar
                     {
                         IsBackButtonVisible = true,
                         IsPaneToggleButtonVisible = true,
@@ -238,14 +235,14 @@ namespace Fluence.Wpf.Tests
                 });
         }
 
-        private static void RunWithTitleBar(Func<Fluent.TitleBar> titleBarFactory, Action<Fluent.TitleBar> testBody)
+        private static void RunWithTitleBar(Func<Controls.TitleBar> titleBarFactory, Action<Controls.TitleBar> testBody)
         {
             RunOnFreshStaThread(delegate
             {
                 Application? application = EnsureApplication();
                 ResourceDictionary? genericDictionary = MergeGenericDictionary(application);
                 Window? window = null;
-                Fluent.TitleBar? titleBar = null;
+                Controls.TitleBar? titleBar = null;
 
                 try
                 {
@@ -285,9 +282,9 @@ namespace Fluence.Wpf.Tests
             });
         }
 
-        private static WpfButton GetTemplateButton(Fluent.TitleBar titleBar, string partName)
+        private static System.Windows.Controls.Button GetTemplateButton(Controls.TitleBar titleBar, string partName)
         {
-            WpfButton? button = titleBar.Template.FindName(partName, titleBar) as WpfButton;
+            System.Windows.Controls.Button? button = titleBar.Template.FindName(partName, titleBar) as System.Windows.Controls.Button;
             Assert.IsNotNull(button, partName + " must exist in the TitleBar template.");
             return button;
         }
@@ -314,7 +311,7 @@ namespace Fluence.Wpf.Tests
             return null;
         }
 
-        private static void InvokeButton(WpfButton button)
+        private static void InvokeButton(System.Windows.Controls.Button button)
         {
             AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(button);
             IInvokeProvider invoke = (IInvokeProvider)peer.GetPattern(PatternInterface.Invoke);

--- a/Fluence.Wpf.Tests/TypographyResourceContractTests.cs
+++ b/Fluence.Wpf.Tests/TypographyResourceContractTests.cs
@@ -29,7 +29,6 @@
 using Fluence.Wpf.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Tests
 {
@@ -49,7 +48,7 @@ namespace Fluence.Wpf.Tests
 
                 try
                 {
-                    WpfTextBlock textBlock = new();
+                    System.Windows.Controls.TextBlock textBlock = new();
                     textBlock.SetTypography(FluentTypography.BodyLarge);
 
                     Assert.AreSame(

--- a/Fluence.Wpf.Tests/WindowPolicyTests.cs
+++ b/Fluence.Wpf.Tests/WindowPolicyTests.cs
@@ -219,7 +219,7 @@ namespace Fluence.Wpf.Tests
             Assert.AreEqual(fallback, plan.BackgroundColor);
             Assert.AreEqual(NativeConstants.DWMWA_COLOR_DEFAULT, plan.CaptionColor,
                 "None must leave the DWM caption color at its default (system-managed).");
-            Assert.IsTrue(plan.SystemBackdropType.HasValue,
+            Assert.IsTrue(plan.SystemBackdropType is not null,
                 "On 22H2 DWM exposes DWMWA_SYSTEMBACKDROP_TYPE - None must emit DWMSBT_NONE to explicitly clear Mica/Acrylic.");
             Assert.AreEqual(NativeConstants.DWMSBT_NONE, plan.SystemBackdropType.Value);
             Assert.IsFalse(plan.UseLegacyMicaEffect);
@@ -234,7 +234,7 @@ namespace Fluence.Wpf.Tests
                 Caps(),
                 Color.FromRgb(0xFA, 0xFA, 0xFA));
 
-            Assert.IsFalse(plan.SystemBackdropType.HasValue,
+            Assert.IsFalse(plan.SystemBackdropType is not null,
                 "Windows 10 does not expose DWMWA_SYSTEMBACKDROP_TYPE - the plan must not attempt to set it.");
         }
 
@@ -257,7 +257,7 @@ namespace Fluence.Wpf.Tests
             Assert.AreEqual(Colors.Transparent, plan.BackgroundColor);
             Assert.AreEqual(NativeConstants.DWMWA_COLOR_NONE, plan.CaptionColor,
                 "Mica must force DWMWA_COLOR_NONE on the caption so the system backdrop shows through.");
-            Assert.IsFalse(plan.SystemBackdropType.HasValue,
+            Assert.IsFalse(plan.SystemBackdropType is not null,
                 "Pre-22H2 must not emit DWMWA_SYSTEMBACKDROP_TYPE - only DWMWA_MICA_EFFECT is legal there.");
             Assert.IsTrue(plan.UseLegacyMicaEffect,
                 "Pre-22H2 Win11 must set the legacy DWMWA_MICA_EFFECT attribute.");
@@ -274,7 +274,7 @@ namespace Fluence.Wpf.Tests
 
             Assert.AreEqual(BackdropType.Mica, plan.EffectiveBackdrop);
             Assert.IsTrue(plan.UseTransparentBackground);
-            Assert.IsTrue(plan.SystemBackdropType.HasValue);
+            Assert.IsTrue(plan.SystemBackdropType is not null);
             Assert.AreEqual(NativeConstants.DWMSBT_MAINWINDOW, plan.SystemBackdropType.Value,
                 "22H2 Mica must emit DWMSBT_MAINWINDOW via DWMWA_SYSTEMBACKDROP_TYPE.");
             Assert.IsFalse(plan.UseLegacyMicaEffect,

--- a/Fluence.Wpf.Tests/WpfTestSta.cs
+++ b/Fluence.Wpf.Tests/WpfTestSta.cs
@@ -209,7 +209,7 @@ namespace Fluence.Wpf.Tests
         {
             lock (LockObj)
             {
-                if (_dispatcher?.Thread.IsAlive == true)
+                if ((_dispatcher?.Thread.IsAlive) is true)
                 {
                     return _dispatcher;
                 }

--- a/Fluence.Wpf.Tests/WpfTestSta.cs
+++ b/Fluence.Wpf.Tests/WpfTestSta.cs
@@ -226,7 +226,7 @@ namespace Fluence.Wpf.Tests
                 thread.SetApartmentState(ApartmentState.STA);
                 thread.IsBackground = true;
                 thread.Start();
-                ready.Wait();
+                ready.Wait(default(CancellationToken));
                 _dispatcher = created;
                 return _dispatcher;
             }

--- a/Fluence.Wpf/ApplicationAccentColorManager.cs
+++ b/Fluence.Wpf/ApplicationAccentColorManager.cs
@@ -78,7 +78,7 @@ namespace Fluence.Wpf
 
         private static AccentPalette Palette => FluenceThemeEngine.CurrentPalette;
 
-        private static bool IsDark => FluenceThemeEngine.ResolvedTheme == ApplicationTheme.Dark;
+        private static bool IsDark => FluenceThemeEngine.ResolvedTheme is ApplicationTheme.Dark;
 
         /// <summary>
         /// Gets the current base system accent color (ARGB). Default is a Windows blue until <see cref="ApplySystemAccent"/> runs.

--- a/Fluence.Wpf/Automation/AutoSuggestBoxAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/AutoSuggestBoxAutomationPeer.cs
@@ -65,7 +65,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.Value
+            return patternInterface is not PatternInterface.Value
                 ? base.GetPattern(patternInterface)
                 : this;
         }

--- a/Fluence.Wpf/Automation/CardAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/CardAutomationPeer.cs
@@ -58,7 +58,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface == PatternInterface.Invoke && CardOwner.IsClickable
+            return patternInterface is PatternInterface.Invoke && CardOwner.IsClickable
                 ? this
                 : base.GetPattern(patternInterface);
         }

--- a/Fluence.Wpf/Automation/DatePickerAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/DatePickerAutomationPeer.cs
@@ -27,7 +27,6 @@
  */
 
 using Fluence.Wpf.Controls;
-using System;
 using System.Globalization;
 using System.Windows.Automation.Peers;
 
@@ -59,15 +58,9 @@ namespace Fluence.Wpf.Automation
         protected override string GetNameCore()
         {
             string name = base.GetNameCore();
-            if (!string.IsNullOrWhiteSpace(name))
-            {
-                return name;
-            }
-
-            DateTime? selectedDate = DatePicker.SelectedDate;
-            return selectedDate.HasValue
-                ? selectedDate.Value.ToString("d", CultureInfo.CurrentCulture)
-                : DatePicker.PlaceholderText;
+            return string.IsNullOrWhiteSpace(name)
+                ? DatePicker.SelectedDate?.ToString("d", CultureInfo.CurrentCulture) ?? DatePicker.PlaceholderText
+                : name;
         }
 
         /// <summary>

--- a/Fluence.Wpf/Automation/DropDownButtonAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/DropDownButtonAutomationPeer.cs
@@ -55,13 +55,13 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.ExpandCollapse
+            return patternInterface is not PatternInterface.ExpandCollapse
                 ? base.GetPattern(patternInterface)
                 : this;
         }
 
         /// <inheritdoc />
-        public virtual ExpandCollapseState ExpandCollapseState => DropDownButton.IsChecked == true
+        public virtual ExpandCollapseState ExpandCollapseState => DropDownButton.IsChecked is true
             ? ExpandCollapseState.Expanded
             : ExpandCollapseState.Collapsed;
 

--- a/Fluence.Wpf/Automation/NavigationViewAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/NavigationViewAutomationPeer.cs
@@ -54,7 +54,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.Selection
+            return patternInterface is not PatternInterface.Selection
                 ? base.GetPattern(patternInterface)
                 : this;
         }

--- a/Fluence.Wpf/Automation/NumberBoxAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/NumberBoxAutomationPeer.cs
@@ -64,7 +64,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.RangeValue
+            return patternInterface is not PatternInterface.RangeValue
                 ? base.GetPattern(patternInterface)
                 : this;
         }

--- a/Fluence.Wpf/Automation/ProgressRingAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/ProgressRingAutomationPeer.cs
@@ -55,7 +55,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.RangeValue || ProgressRing.IsIndeterminate
+            return patternInterface is not PatternInterface.RangeValue || ProgressRing.IsIndeterminate
                 ? base.GetPattern(patternInterface)
                 : this;
         }

--- a/Fluence.Wpf/Automation/RatingControlAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/RatingControlAutomationPeer.cs
@@ -57,7 +57,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.RangeValue
+            return patternInterface is not PatternInterface.RangeValue
                 ? base.GetPattern(patternInterface)
                 : this;
         }

--- a/Fluence.Wpf/Automation/SplitButtonAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/SplitButtonAutomationPeer.cs
@@ -32,7 +32,6 @@ using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Input;
-using ToggleButton = System.Windows.Controls.Primitives.ToggleButton;
 
 namespace Fluence.Wpf.Automation
 {
@@ -77,7 +76,7 @@ namespace Fluence.Wpf.Automation
             // visual tree see no-op behavior; with a template applied, the overridden
             // PropertyChanged wiring flips the popup via the secondary button.
             SplitButton thisButton = SplitButton;
-            ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as ToggleButton;
+            System.Windows.Controls.Primitives.ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as System.Windows.Controls.Primitives.ToggleButton;
             _ = toggle?.IsChecked = true;
         }
 
@@ -85,7 +84,7 @@ namespace Fluence.Wpf.Automation
         public virtual void Collapse()
         {
             SplitButton thisButton = SplitButton;
-            ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as ToggleButton;
+            System.Windows.Controls.Primitives.ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as System.Windows.Controls.Primitives.ToggleButton;
             _ = toggle?.IsChecked = false;
         }
 

--- a/Fluence.Wpf/Automation/TimePickerAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/TimePickerAutomationPeer.cs
@@ -59,15 +59,11 @@ namespace Fluence.Wpf.Automation
         protected override string GetNameCore()
         {
             string name = base.GetNameCore();
-            if (!string.IsNullOrWhiteSpace(name))
-            {
-                return name;
-            }
-
-            TimeSpan? selectedTime = TimePicker.SelectedTime;
-            return selectedTime.HasValue
-                ? DateTime.Today.Add(selectedTime.Value).ToString("t", CultureInfo.CurrentCulture)
-                : TimePicker.PlaceholderText;
+            return string.IsNullOrWhiteSpace(name)
+                ? TimePicker.SelectedTime is TimeSpan selectedTime
+                ? DateTime.Today.Add(selectedTime).ToString("t", CultureInfo.CurrentCulture)
+                : TimePicker.PlaceholderText
+                : name;
         }
 
         /// <summary>

--- a/Fluence.Wpf/Automation/ToggleSplitButtonAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/ToggleSplitButtonAutomationPeer.cs
@@ -30,7 +30,6 @@ using Fluence.Wpf.Controls;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
-using ToggleButton = System.Windows.Controls.Primitives.ToggleButton;
 
 namespace Fluence.Wpf.Automation
 {
@@ -88,7 +87,7 @@ namespace Fluence.Wpf.Automation
             // part of the template; flipping the part opens the popup via the control's
             // Checked/Unchecked wiring. Without an applied template this is a no-op.
             ToggleSplitButton thisButton = ToggleSplitButton;
-            ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as ToggleButton;
+            System.Windows.Controls.Primitives.ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as System.Windows.Controls.Primitives.ToggleButton;
             _ = toggle?.IsChecked = true;
         }
 
@@ -96,7 +95,7 @@ namespace Fluence.Wpf.Automation
         public virtual void Collapse()
         {
             ToggleSplitButton thisButton = ToggleSplitButton;
-            ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as ToggleButton;
+            System.Windows.Controls.Primitives.ToggleButton? toggle = thisButton.Template?.FindName("PART_SecondaryButton", thisButton) as System.Windows.Controls.Primitives.ToggleButton;
             _ = toggle?.IsChecked = false;
         }
 

--- a/Fluence.Wpf/Automation/ToggleSwitchAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/ToggleSwitchAutomationPeer.cs
@@ -76,7 +76,7 @@ namespace Fluence.Wpf.Automation
         /// <inheritdoc />
         public override object GetPattern(PatternInterface patternInterface)
         {
-            return patternInterface != PatternInterface.Toggle
+            return patternInterface is not PatternInterface.Toggle
                 ? base.GetPattern(patternInterface)
                 : this;
         }
@@ -90,7 +90,7 @@ namespace Fluence.Wpf.Automation
         public virtual void Toggle()
         {
             bool? current = ToggleSwitch.IsChecked;
-            ToggleSwitch.IsChecked = current != true;
+            ToggleSwitch.IsChecked = current is not true;
         }
 
         /// <summary>

--- a/Fluence.Wpf/Controls/AutoSuggestBox.cs
+++ b/Fluence.Wpf/Controls/AutoSuggestBox.cs
@@ -349,22 +349,22 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (e.Key == Key.Down && IsSuggestionListOpen)
+            if (e.Key is Key.Down && IsSuggestionListOpen)
             {
                 MoveSuggestionSelection(1);
                 e.Handled = true;
             }
-            else if (e.Key == Key.Up && IsSuggestionListOpen)
+            else if (e.Key is Key.Up && IsSuggestionListOpen)
             {
                 MoveSuggestionSelection(-1);
                 e.Handled = true;
             }
-            else if (e.Key == Key.Enter)
+            else if (e.Key is Key.Enter)
             {
                 OnEnterKeyPressed();
                 e.Handled = true;
             }
-            else if (e.Key == Key.Escape && IsSuggestionListOpen)
+            else if (e.Key is Key.Escape && IsSuggestionListOpen)
             {
                 SetCurrentValue(IsSuggestionListOpenProperty, value: false);
                 e.Handled = true;
@@ -653,7 +653,7 @@ namespace Fluence.Wpf.Controls
             }
 
             int count = _suggestionsList.Items.Count;
-            if (count == 0)
+            if (count is 0)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/CaptionButtonChrome.cs
+++ b/Fluence.Wpf/Controls/CaptionButtonChrome.cs
@@ -60,7 +60,7 @@ namespace Fluence.Wpf.Controls
             out Visibility visibility,
             out bool isEnabled)
         {
-            isEnabled = resizeMode != ResizeMode.NoResize;
+            isEnabled = resizeMode is not ResizeMode.NoResize;
             visibility = isEnabled ? Visibility.Visible : Visibility.Collapsed;
         }
 
@@ -122,8 +122,8 @@ namespace Fluence.Wpf.Controls
 
             if (resizeMode is not ResizeMode.NoResize and not ResizeMode.CanMinimize)
             {
-                maximizeEnabled = maximizeVisibility == Visibility.Visible;
-                restoreEnabled = restoreVisibility == Visibility.Visible;
+                maximizeEnabled = maximizeVisibility is Visibility.Visible;
+                restoreEnabled = restoreVisibility is Visibility.Visible;
             }
             else
             {
@@ -149,14 +149,14 @@ namespace Fluence.Wpf.Controls
             out Visibility maximizeVisibility,
             out Visibility restoreVisibility)
         {
-            if (resizeMode == ResizeMode.NoResize)
+            if (resizeMode is ResizeMode.NoResize)
             {
                 maximizeVisibility = Visibility.Collapsed;
                 restoreVisibility = Visibility.Collapsed;
                 return;
             }
 
-            if (windowState == WindowState.Maximized)
+            if (windowState is WindowState.Maximized)
             {
                 maximizeVisibility = Visibility.Collapsed;
                 restoreVisibility = Visibility.Visible;

--- a/Fluence.Wpf/Controls/CheckBox.cs
+++ b/Fluence.Wpf/Controls/CheckBox.cs
@@ -92,9 +92,9 @@ namespace Fluence.Wpf.Controls
         /// <summary>
         /// Gets or sets the description text displayed below the check box content.
         /// </summary>
-        public string Description
+        public string? Description
         {
-            get => (string)GetValue(DescriptionProperty);
+            get => (string?)GetValue(DescriptionProperty);
             set => SetValue(DescriptionProperty, value);
         }
     }

--- a/Fluence.Wpf/Controls/ColorPicker.cs
+++ b/Fluence.Wpf/Controls/ColorPicker.cs
@@ -859,7 +859,7 @@ namespace Fluence.Wpf.Controls
         private void UpdatePreviousSwatch()
         {
             Color? previous = PreviousColor;
-            if (_previousSwatchBorder is null || !previous.HasValue)
+            if (_previousSwatchBorder is null || previous is null)
             {
                 return;
             }

--- a/Fluence.Wpf/Controls/ColorPicker.cs
+++ b/Fluence.Wpf/Controls/ColorPicker.cs
@@ -604,7 +604,7 @@ namespace Fluence.Wpf.Controls
         private static void OnIsAlphaEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             ColorPicker picker = (ColorPicker)d;
-            if (e.NewValue is false && picker._alpha != 255)
+            if (e.NewValue is false && picker._alpha is not 255)
             {
                 // Disabling alpha pins the picker back to fully opaque, like WinUI.
                 picker.SetColorFromHsv(picker._hue, picker._saturation, picker._value, 255);
@@ -767,7 +767,7 @@ namespace Fluence.Wpf.Controls
         /// </summary>
         private void UpdateChannelTextBoxes()
         {
-            if (_activeTextInputGroup != TextInputGroup.Rgb)
+            if (_activeTextInputGroup is not TextInputGroup.Rgb)
             {
                 Color color = Color;
                 _redTextBox?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, color.R.ToString(CultureInfo.InvariantCulture));
@@ -775,14 +775,14 @@ namespace Fluence.Wpf.Controls
                 _blueTextBox?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, color.B.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (_activeTextInputGroup != TextInputGroup.Hsv)
+            if (_activeTextInputGroup is not TextInputGroup.Hsv)
             {
                 _hueTextBox?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, ((int)Math.Round(_hue, MidpointRounding.ToEven)).ToString(CultureInfo.InvariantCulture));
                 _saturationTextBox?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, ((int)Math.Round(_saturation * 100, MidpointRounding.ToEven)).ToString(CultureInfo.InvariantCulture));
                 _valueTextBox?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, ((int)Math.Round(_value * 100, MidpointRounding.ToEven)).ToString(CultureInfo.InvariantCulture));
             }
 
-            if (_activeTextInputGroup != TextInputGroup.Alpha)
+            if (_activeTextInputGroup is not TextInputGroup.Alpha)
             {
                 int percent = (int)Math.Round(_alpha / 255.0 * 100, MidpointRounding.ToEven);
                 _alphaTextBox?.SetCurrentValue(
@@ -1321,7 +1321,7 @@ namespace Fluence.Wpf.Controls
                 return false;
             }
 
-            if (hex.Length == 6)
+            if (hex.Length is 6)
             {
                 argb |= 0xFF000000;
             }

--- a/Fluence.Wpf/Controls/ComboBox.cs
+++ b/Fluence.Wpf/Controls/ComboBox.cs
@@ -296,7 +296,7 @@ namespace Fluence.Wpf.Controls
         private bool IsSelectedIndexExplicitlySet()
         {
             ValueSource source = DependencyPropertyHelper.GetValueSource(this, SelectedIndexProperty);
-            return source.BaseValueSource != BaseValueSource.Default;
+            return source.BaseValueSource is not BaseValueSource.Default;
         }
 
         private void TryAutoSelectFirstItem()

--- a/Fluence.Wpf/Controls/ContentDialog.cs
+++ b/Fluence.Wpf/Controls/ContentDialog.cs
@@ -532,7 +532,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (e.Key == Key.Escape)
+            if (e.Key is Key.Escape)
             {
                 HandleButtonInvoked(CloseButtonClick, CloseButtonCommand, CloseButtonCommandParameter, ContentDialogResult.None);
                 e.Handled = true;
@@ -553,7 +553,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (e.Key == Key.Enter)
+            if (e.Key is Key.Enter)
             {
                 IInputElement? focused = Keyboard.FocusedElement;
                 if (ReferenceEquals(focused, _primaryButton)
@@ -777,7 +777,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (command?.CanExecute(commandParameter) == true)
+            if ((command?.CanExecute(commandParameter)) is true)
             {
                 command.Execute(commandParameter);
             }
@@ -792,19 +792,19 @@ namespace Fluence.Wpf.Controls
         /// <returns><see langword="true"/> when a default button was invoked.</returns>
         private bool TryInvokeDefaultButton()
         {
-            if (DefaultButton == ContentDialogButton.Primary && IsPrimaryButtonEnabled && !string.IsNullOrWhiteSpace(PrimaryButtonText))
+            if (DefaultButton is ContentDialogButton.Primary && IsPrimaryButtonEnabled && !string.IsNullOrWhiteSpace(PrimaryButtonText))
             {
                 HandleButtonInvoked(PrimaryButtonClick, PrimaryButtonCommand, PrimaryButtonCommandParameter, ContentDialogResult.Primary);
                 return true;
             }
 
-            if (DefaultButton == ContentDialogButton.Secondary && IsSecondaryButtonEnabled && !string.IsNullOrWhiteSpace(SecondaryButtonText))
+            if (DefaultButton is ContentDialogButton.Secondary && IsSecondaryButtonEnabled && !string.IsNullOrWhiteSpace(SecondaryButtonText))
             {
                 HandleButtonInvoked(SecondaryButtonClick, SecondaryButtonCommand, SecondaryButtonCommandParameter, ContentDialogResult.Secondary);
                 return true;
             }
 
-            if (DefaultButton == ContentDialogButton.Close && !string.IsNullOrWhiteSpace(CloseButtonText))
+            if (DefaultButton is ContentDialogButton.Close && !string.IsNullOrWhiteSpace(CloseButtonText))
             {
                 HandleButtonInvoked(CloseButtonClick, CloseButtonCommand, CloseButtonCommandParameter, ContentDialogResult.None);
                 return true;
@@ -837,7 +837,7 @@ namespace Fluence.Wpf.Controls
                 ContentDialogButton.None or _ => null,
             };
 
-            if (defaultButton?.IsEnabled == true && defaultButton.Visibility == Visibility.Visible)
+            if ((defaultButton?.IsEnabled) is true && defaultButton.Visibility is Visibility.Visible)
             {
                 _ = defaultButton.Focus();
                 return;

--- a/Fluence.Wpf/Controls/DatePicker.cs
+++ b/Fluence.Wpf/Controls/DatePicker.cs
@@ -391,9 +391,9 @@ defaultValue: null,
         /// <returns>The formatted string for the specified field.</returns>
         private static string FormatSegment(DateField field, DateTime date, CultureInfo culture)
         {
-            return field == DateField.Day
+            return field is DateField.Day
                 ? date.Day.ToString(culture)
-                : field == DateField.Month
+                : field is DateField.Month
                     ? GetGregorianFormat(culture).GetMonthName(date.Month)
                     : date.Year.ToString(culture);
         }
@@ -436,7 +436,7 @@ defaultValue: null,
         /// <returns>The star-width weight for the specified field.</returns>
         private static double GetFieldStarWidth(DateField field)
         {
-            return field == DateField.Month ? 132 : 78;
+            return field is DateField.Month ? 132 : 78;
         }
 
         /// <summary>
@@ -535,19 +535,19 @@ defaultValue: null,
         /// <param name="e">The event data.</param>
         private void OnPopupPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Handled || _popup?.IsOpen != true)
+            if (e.Handled || (_popup?.IsOpen) is not true)
             {
                 return;
             }
 
-            if (e.Key == Key.Escape)
+            if (e.Key is Key.Escape)
             {
                 ClosePopup();
                 e.Handled = true;
                 return;
             }
 
-            if (e.Key == Key.Enter)
+            if (e.Key is Key.Enter)
             {
                 IInputElement? focused = Keyboard.FocusedElement;
                 if (ReferenceEquals(focused, _acceptButton) || ReferenceEquals(focused, _cancelButton))
@@ -567,7 +567,7 @@ defaultValue: null,
         /// </summary>
         private void MoveFocusIntoPopup()
         {
-            if (_popup?.IsOpen != true)
+            if ((_popup?.IsOpen) is not true)
             {
                 return;
             }
@@ -598,7 +598,7 @@ defaultValue: null,
             foreach (DateField field in GetOrderedVisibleFields())
             {
                 Selector? column = GetSelector(field);
-                if (column is not null && column.Visibility == Visibility.Visible)
+                if (column?.Visibility is Visibility.Visible)
                 {
                     return column;
                 }
@@ -728,7 +728,7 @@ defaultValue: null,
 
         private void ClosePopup()
         {
-            if (_popup?.IsOpen == true)
+            if ((_popup?.IsOpen) is true)
             {
                 // Closing through the control's own pipeline must not arm the light-dismiss
                 // reopen lockout; Popup.Closed is raised synchronously from the set below.
@@ -765,9 +765,9 @@ defaultValue: null,
         /// <returns>The selector column for the specified field.</returns>
         private Selector? GetSelector(DateField field)
         {
-            return field == DateField.Day
+            return field is DateField.Day
                 ? _dayList
-                : field == DateField.Month ? _monthList : _yearList;
+                : field is DateField.Month ? _monthList : _yearList;
         }
 
         /// <summary>
@@ -779,9 +779,9 @@ defaultValue: null,
             List<DateField> visible = [];
             foreach (DateField field in GetCultureOrderedFields(CultureInfo.CurrentCulture.DateTimeFormat))
             {
-                bool isVisible = (field == DateField.Day && DayVisible)
-                    || (field == DateField.Month && MonthVisible)
-                    || (field == DateField.Year && YearVisible);
+                bool isVisible = (field is DateField.Day && DayVisible)
+                    || (field is DateField.Month && MonthVisible)
+                    || (field is DateField.Year && YearVisible);
                 if (isVisible)
                 {
                     visible.Add(field);
@@ -819,7 +819,7 @@ defaultValue: null,
                     segment.Text = selectedDate.HasValue
                         ? FormatSegment(fields[position], selectedDate.Value, culture)
                         : string.Empty;
-                    segment.HorizontalAlignment = fields[position] == DateField.Month
+                    segment.HorizontalAlignment = fields[position] is DateField.Month
                         ? HorizontalAlignment.Left
                         : HorizontalAlignment.Center;
                     segment.Visibility = Visibility.Visible;

--- a/Fluence.Wpf/Controls/DatePicker.cs
+++ b/Fluence.Wpf/Controls/DatePicker.cs
@@ -491,7 +491,7 @@ defaultValue: null,
         /// </summary>
         private bool IsWithinLightDismissReopenLockout()
         {
-            return _lastLightDismissTick.HasValue
+            return _lastLightDismissTick is not null
                 && unchecked(Environment.TickCount - _lastLightDismissTick.Value) < LightDismissReopenLockoutMilliseconds;
         }
 
@@ -816,7 +816,7 @@ defaultValue: null,
 
                 if (position < fields.Count)
                 {
-                    segment.Text = selectedDate.HasValue
+                    segment.Text = selectedDate is not null
                         ? FormatSegment(fields[position], selectedDate.Value, culture)
                         : string.Empty;
                     segment.HorizontalAlignment = fields[position] is DateField.Month

--- a/Fluence.Wpf/Controls/DockPanel.cs
+++ b/Fluence.Wpf/Controls/DockPanel.cs
@@ -80,7 +80,7 @@ namespace Fluence.Wpf.Controls
         {
             UIElementCollection children = InternalChildren;
             int count = children.Count;
-            if (count == 0)
+            if (count is 0)
             {
                 return new(0, 0);
             }
@@ -141,7 +141,7 @@ namespace Fluence.Wpf.Controls
         {
             UIElementCollection children = InternalChildren;
             int count = children.Count;
-            if (count == 0)
+            if (count is 0)
             {
                 return finalSize;
             }

--- a/Fluence.Wpf/Controls/DropDownButton.cs
+++ b/Fluence.Wpf/Controls/DropDownButton.cs
@@ -152,7 +152,7 @@ namespace Fluence.Wpf.Controls
             {
                 _popup.PlacementTarget = this;
                 AttachPopupHandlers(_popup);
-                _popup.IsOpen = IsChecked == true;
+                _popup.IsOpen = IsChecked is true;
             }
         }
 
@@ -162,7 +162,7 @@ namespace Fluence.Wpf.Controls
             base.OnPropertyChanged(e);
             if (e.Property == IsCheckedProperty && _popup is not null)
             {
-                _popup.IsOpen = IsChecked == true;
+                _popup.IsOpen = IsChecked is true;
             }
         }
 

--- a/Fluence.Wpf/Controls/FluenceWindow.cs
+++ b/Fluence.Wpf/Controls/FluenceWindow.cs
@@ -780,7 +780,7 @@ namespace Fluence.Wpf.Controls
         /// </summary>
         private void UpdateShellMetrics()
         {
-            MarginMaximized = WindowState == WindowState.Maximized ? new Thickness(6) : new Thickness(0);
+            MarginMaximized = WindowState is WindowState.Maximized ? new Thickness(6) : new Thickness(0);
             _windowChrome.ResizeBorderThickness = WindowPolicy.GetResizeBorderThickness(WindowState, ResizeMode);
         }
 
@@ -887,9 +887,9 @@ namespace Fluence.Wpf.Controls
         private static Color GetFallbackBackgroundColor()
         {
             ApplicationTheme resolvedTheme = ApplicationThemeManager.GetResolvedTheme();
-            return resolvedTheme == ApplicationTheme.Dark
+            return resolvedTheme is ApplicationTheme.Dark
                 ? Color.FromRgb(0x20, 0x20, 0x20)
-                : resolvedTheme == ApplicationTheme.HighContrast
+                : resolvedTheme is ApplicationTheme.HighContrast
                 ? SystemColors.WindowColor
                 : Color.FromRgb(0xFA, 0xFA, 0xFA);
         }
@@ -937,12 +937,12 @@ namespace Fluence.Wpf.Controls
         /// </remarks>
         private void FillClientAreaForSizeToContent()
         {
-            if (SizeToContent == SizeToContent.Manual || _isFillingClientArea)
+            if (SizeToContent is SizeToContent.Manual || _isFillingClientArea)
             {
                 return;
             }
 
-            if (VisualChildrenCount == 0 || GetVisualChild(0) is not UIElement child)
+            if (VisualChildrenCount is 0 || GetVisualChild(0) is not UIElement child)
             {
                 return;
             }
@@ -1003,7 +1003,7 @@ namespace Fluence.Wpf.Controls
             if (IsCaptionChromeOverrideExplicit(IsMinimizeButtonVisibleProperty))
             {
                 minimizeVisibility = IsMinimizeButtonVisible;
-                minimizeEnabled = minimizeVisibility == Visibility.Visible;
+                minimizeEnabled = minimizeVisibility is Visibility.Visible;
             }
             if (!IsMinimizable)
             {
@@ -1023,9 +1023,9 @@ namespace Fluence.Wpf.Controls
             if (IsCaptionChromeOverrideExplicit(IsMaximizeButtonVisibleProperty))
             {
                 ApplyMaximizeRestoreVisibilityOverride(IsMaximizeButtonVisible, out maxVis, out restVis);
-                bool explicitlyVisible = IsMaximizeButtonVisible == Visibility.Visible;
-                maxEn = explicitlyVisible && WindowState != WindowState.Maximized;
-                restEn = explicitlyVisible && WindowState == WindowState.Maximized;
+                bool explicitlyVisible = IsMaximizeButtonVisible is Visibility.Visible;
+                maxEn = explicitlyVisible && WindowState is not WindowState.Maximized;
+                restEn = explicitlyVisible && WindowState is WindowState.Maximized;
             }
             if (!IsMaximizable)
             {
@@ -1043,7 +1043,7 @@ namespace Fluence.Wpf.Controls
             if (IsCaptionChromeOverrideExplicit(IsCloseButtonVisibleProperty))
             {
                 closeVisibility = IsCloseButtonVisible;
-                closeEnabled = closeVisibility == Visibility.Visible;
+                closeEnabled = closeVisibility is Visibility.Visible;
             }
             if (!IsClosable)
             {
@@ -1070,9 +1070,9 @@ namespace Fluence.Wpf.Controls
             Visibility restoreVisibility,
             Visibility closeVisibility)
         {
-            bool maximizeOccupiesSlot = maximizeVisibility != Visibility.Collapsed || restoreVisibility != Visibility.Collapsed;
-            bool minimizeOccupiesSlot = minimizeVisibility != Visibility.Collapsed;
-            bool closeOccupiesSlot = closeVisibility != Visibility.Collapsed;
+            bool maximizeOccupiesSlot = maximizeVisibility is not Visibility.Collapsed || restoreVisibility is not Visibility.Collapsed;
+            bool minimizeOccupiesSlot = minimizeVisibility is not Visibility.Collapsed;
+            bool closeOccupiesSlot = closeVisibility is not Visibility.Collapsed;
 
             Grid.SetColumn(_closeButton, 2);
             int nextSlot = 2;
@@ -1109,16 +1109,16 @@ namespace Fluence.Wpf.Controls
         /// <param name="restoreVisibility">The resulting visibility of the restore button.</param>
         private void ApplyMaximizeRestoreVisibilityOverride(Visibility visibility, out Visibility maximizeVisibility, out Visibility restoreVisibility)
         {
-            if (visibility == Visibility.Visible)
+            if (visibility is Visibility.Visible)
             {
-                maximizeVisibility = WindowState == WindowState.Maximized ? Visibility.Collapsed : Visibility.Visible;
-                restoreVisibility = WindowState == WindowState.Maximized ? Visibility.Visible : Visibility.Collapsed;
+                maximizeVisibility = WindowState is WindowState.Maximized ? Visibility.Collapsed : Visibility.Visible;
+                restoreVisibility = WindowState is WindowState.Maximized ? Visibility.Visible : Visibility.Collapsed;
                 return;
             }
-            if (visibility == Visibility.Hidden)
+            if (visibility is Visibility.Hidden)
             {
-                maximizeVisibility = WindowState == WindowState.Maximized ? Visibility.Collapsed : Visibility.Hidden;
-                restoreVisibility = WindowState == WindowState.Maximized ? Visibility.Hidden : Visibility.Collapsed;
+                maximizeVisibility = WindowState is WindowState.Maximized ? Visibility.Collapsed : Visibility.Hidden;
+                restoreVisibility = WindowState is WindowState.Maximized ? Visibility.Hidden : Visibility.Collapsed;
                 return;
             }
             maximizeVisibility = Visibility.Collapsed;
@@ -1162,13 +1162,13 @@ namespace Fluence.Wpf.Controls
                 int result = HitTestTitleBar(lParam);
                 if (result == NativeConstants.HTMAXBUTTON)
                 {
-                    SetSnapHover(WindowState == WindowState.Maximized ? _restoreButton : _maximizeButton);
+                    SetSnapHover(WindowState is WindowState.Maximized ? _restoreButton : _maximizeButton);
                 }
                 else
                 {
                     ClearSnapHover();
                 }
-                if (result != 0)
+                if (result is not 0)
                 {
                     handled = true;
                     return new IntPtr(result);
@@ -1297,15 +1297,15 @@ namespace Fluence.Wpf.Controls
         private void HandleMaxButtonClick(ref bool handled)
         {
             ClearSnapHover();
-            if (WindowState == WindowState.Maximized)
+            if (WindowState is WindowState.Maximized)
             {
-                if (_restoreButton is not null && _restoreButton.Visibility == Visibility.Visible && _restoreButton.IsEnabled)
+                if (_restoreButton?.Visibility is Visibility.Visible && _restoreButton.IsEnabled)
                 {
                     handled = true;
                     RestoreWindowDirect();
                 }
             }
-            else if (_maximizeButton is not null && _maximizeButton.Visibility == Visibility.Visible && _maximizeButton.IsEnabled)
+            else if (_maximizeButton?.Visibility is Visibility.Visible && _maximizeButton.IsEnabled)
             {
                 handled = true;
                 MaximizeWindowDirect();
@@ -1346,13 +1346,13 @@ namespace Fluence.Wpf.Controls
             bool shouldExposeSnapFlyout = SnapLayoutHelper.IsSnapLayoutEnabled()
                 && IsMaximizable
                 && OsVersionHelper.IsWindows11;
-            if (_maximizeButton is not null && _maximizeButton.Visibility == Visibility.Visible &&
+            if (_maximizeButton?.Visibility is Visibility.Visible &&
                 _maximizeButton.IsEnabled &&
                 IsOverElement(_maximizeButton, point))
             {
                 return shouldExposeSnapFlyout ? NativeConstants.HTMAXBUTTON : 0;
             }
-            if (_restoreButton is not null && _restoreButton.Visibility == Visibility.Visible &&
+            if (_restoreButton?.Visibility is Visibility.Visible &&
                 _restoreButton.IsEnabled &&
                 IsOverElement(_restoreButton, point))
             {
@@ -1360,10 +1360,10 @@ namespace Fluence.Wpf.Controls
             }
 
             // Minimize and close: return 0 so hit falls through to client area; WPF Button + Command fire.
-            if ((_minimizeButton is not null && _minimizeButton.Visibility == Visibility.Visible &&
-                 IsOverElement(_minimizeButton, point)) ||
-                (_closeButton is not null && _closeButton.Visibility == Visibility.Visible &&
-                 IsOverElement(_closeButton, point)))
+            if ((_minimizeButton?.Visibility is Visibility.Visible &&
+                IsOverElement(_minimizeButton, point)) ||
+                (_closeButton?.Visibility is Visibility.Visible &&
+                IsOverElement(_closeButton, point)))
             {
                 return 0;
             }
@@ -1391,7 +1391,7 @@ namespace Fluence.Wpf.Controls
         private bool TryGetTopResizeHit(Point point, out int hit)
         {
             hit = 0;
-            if (WindowState == WindowState.Maximized ||
+            if (WindowState is WindowState.Maximized ||
                 ResizeMode is ResizeMode.NoResize or ResizeMode.CanMinimize)
             {
                 return false;
@@ -1428,7 +1428,7 @@ namespace Fluence.Wpf.Controls
             }
 
             ClearSnapHover();
-            if (button?.IsEnabled == true)
+            if ((button?.IsEnabled) is true)
             {
                 // Use resource references (not a TryFindResource snapshot) so the snap-hover colors
                 // track theme/accent/high-contrast changes and mirror the WindowButtonStyle
@@ -1463,7 +1463,7 @@ namespace Fluence.Wpf.Controls
         /// <returns><see langword="true"/> if the point falls within the element's bounds; otherwise, <see langword="false"/>.</returns>
         private bool IsOverElement(UIElement element, Point windowPoint)
         {
-            if (element is null || element.Visibility != Visibility.Visible)
+            if (element is null || element.Visibility is not Visibility.Visible)
             {
                 return false;
             }
@@ -1516,16 +1516,16 @@ namespace Fluence.Wpf.Controls
                 ResizeMode.CanResizeWithGrip;
             bool allowedByExplicitDp =
                 IsCaptionChromeOverrideExplicit(IsMaximizeButtonVisibleProperty) &&
-                IsMaximizeButtonVisible == Visibility.Visible;
+                IsMaximizeButtonVisible is Visibility.Visible;
             e.CanExecute = (allowedByResizeMode || allowedByExplicitDp) && IsMaximizable;
         }
 
         private void OnCanMinimizeWindow(object sender, CanExecuteRoutedEventArgs e)
         {
-            bool allowedByResizeMode = ResizeMode != ResizeMode.NoResize;
+            bool allowedByResizeMode = ResizeMode is not ResizeMode.NoResize;
             bool allowedByExplicitDp =
                 IsCaptionChromeOverrideExplicit(IsMinimizeButtonVisibleProperty) &&
-                IsMinimizeButtonVisible == Visibility.Visible;
+                IsMinimizeButtonVisible is Visibility.Visible;
             e.CanExecute = (allowedByResizeMode || allowedByExplicitDp) && IsMinimizable;
         }
 

--- a/Fluence.Wpf/Controls/FlyoutBase.cs
+++ b/Fluence.Wpf/Controls/FlyoutBase.cs
@@ -126,7 +126,7 @@ namespace Fluence.Wpf.Controls
         /// <summary>
         /// Gets a value indicating whether the flyout is currently open.
         /// </summary>
-        public bool IsOpen => HostPopup?.IsOpen == true;
+        public bool IsOpen => (HostPopup?.IsOpen) is true;
 
         /// <summary>
         /// Gets the popup that hosts the presenter. Created lazily on the first
@@ -232,7 +232,7 @@ namespace Fluence.Wpf.Controls
         /// </summary>
         public void Hide()
         {
-            if (HostPopup?.IsOpen != true)
+            if ((HostPopup?.IsOpen) is not true)
             {
                 return;
             }
@@ -300,11 +300,11 @@ namespace Fluence.Wpf.Controls
             CustomPopupPlacement below = new(new Point(centeredX, targetSize.Height + offset.Y), PopupPrimaryAxis.Horizontal);
             CustomPopupPlacement leftOf = new(new Point(-popupSize.Width + offset.X, centeredY), PopupPrimaryAxis.Vertical);
             CustomPopupPlacement rightOf = new(new Point(targetSize.Width + offset.X, centeredY), PopupPrimaryAxis.Vertical);
-            return side == PlacementMode.Top
+            return side is PlacementMode.Top
                 ? [above, below]
-                : side == PlacementMode.Left
+                : side is PlacementMode.Left
                     ? [leftOf, rightOf]
-                    : side == PlacementMode.Right ? [rightOf, leftOf] : [below, above];
+                    : side is PlacementMode.Right ? [rightOf, leftOf] : [below, above];
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace Fluence.Wpf.Controls
         /// <param name="e">The key event data.</param>
         private void OnPresenterPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (!e.Handled && e.Key == Key.Escape)
+            if (!e.Handled && e.Key is Key.Escape)
             {
                 Hide();
                 e.Handled = true;

--- a/Fluence.Wpf/Controls/FontIcon.cs
+++ b/Fluence.Wpf/Controls/FontIcon.cs
@@ -250,7 +250,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            mirror.ScaleX = (MirroredWhenRightToLeft && FlowDirection == FlowDirection.RightToLeft) ? -1 : 1;
+            mirror.ScaleX = (MirroredWhenRightToLeft && FlowDirection is FlowDirection.RightToLeft) ? -1 : 1;
         }
 
         private void ApplySpinState()

--- a/Fluence.Wpf/Controls/HyperlinkButton.cs
+++ b/Fluence.Wpf/Controls/HyperlinkButton.cs
@@ -144,7 +144,7 @@ namespace Fluence.Wpf.Controls
             base.OnClick();
             if (NavigateUri is Uri uri)
             {
-                _ = Process.Start(uri.AbsoluteUri);
+                _ = Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
             }
         }
 

--- a/Fluence.Wpf/Controls/NavigationView.cs
+++ b/Fluence.Wpf/Controls/NavigationView.cs
@@ -669,7 +669,7 @@ defaultValue: null,
 
         internal void InvokeItem(NavigationViewItem item)
         {
-            if (item?.IsEnabled != true)
+            if ((item?.IsEnabled) is not true)
             {
                 return;
             }
@@ -916,7 +916,7 @@ defaultValue: null,
             bool animatePaneWidth = IsLeftFamilyMode(oldMode) && IsLeftFamilyMode(newMode);
             double fromWidth = nav.GetCurrentPaneColumnWidth();
 
-            if (newMode == NavigationViewPaneDisplayMode.LeftCompact)
+            if (newMode is NavigationViewPaneDisplayMode.LeftCompact)
             {
                 nav.SetCurrentValue(IsPaneOpenProperty, value: false);
             }
@@ -946,14 +946,14 @@ defaultValue: null,
         private static object CoerceIsPaneOpen(DependencyObject d, object baseValue)
         {
             NavigationView nav = (NavigationView)d;
-            return nav.PaneDisplayMode == NavigationViewPaneDisplayMode.Top || (bool)baseValue;
+            return nav.PaneDisplayMode is NavigationViewPaneDisplayMode.Top || (bool)baseValue;
         }
 
         private static object CoerceIsPaneToggleButtonVisible(DependencyObject d, object baseValue)
         {
             _ = baseValue;
             NavigationView nav = (NavigationView)d;
-            return nav.PaneDisplayMode != NavigationViewPaneDisplayMode.Top;
+            return nav.PaneDisplayMode is not NavigationViewPaneDisplayMode.Top;
         }
 
         private void CoerceTopPaneProperties()
@@ -970,11 +970,11 @@ defaultValue: null,
             }
 
             bool? desiredValue = null;
-            if (PaneDisplayMode == NavigationViewPaneDisplayMode.Left)
+            if (PaneDisplayMode is NavigationViewPaneDisplayMode.Left)
             {
                 desiredValue = true;
             }
-            else if (PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
+            else if (PaneDisplayMode is NavigationViewPaneDisplayMode.Top)
             {
                 desiredValue = false;
             }
@@ -1113,7 +1113,7 @@ defaultValue: null,
             }
 
             GridLength current = _paneColumn.Width;
-            return current.GridUnitType == GridUnitType.Pixel
+            return current.GridUnitType is GridUnitType.Pixel
                 ? current.Value
                 : GetClosedPaneWidth();
         }
@@ -1154,9 +1154,9 @@ defaultValue: null,
                 return;
             }
 
-            bool topMode = PaneDisplayMode == NavigationViewPaneDisplayMode.Top;
+            bool topMode = PaneDisplayMode is NavigationViewPaneDisplayMode.Top;
             bool shouldShow = IsLoaded
-                && SelectedFooterItem?.IsVisible == true
+                && (SelectedFooterItem?.IsVisible) is true
                 && SelectedFooterItem.ActualHeight > 0;
 
             if (!shouldShow)
@@ -1321,7 +1321,7 @@ defaultValue: null,
                 return;
             }
 
-            bool topMode = PaneDisplayMode == NavigationViewPaneDisplayMode.Top;
+            bool topMode = PaneDisplayMode is NavigationViewPaneDisplayMode.Top;
             Point targetPosition = CalculateIndicatorPosition(nvi, _selectionIndicator, _indicatorHost, topMode);
             if (!animate || !_indicatorPositioned)
             {
@@ -1368,7 +1368,7 @@ defaultValue: null,
 
         private bool ShouldIndentSelectionIndicator(NavigationViewItem item, bool topMode)
         {
-            return !topMode && item?.IsChildItem == true && (IsPaneOpen || (PaneDisplayMode != NavigationViewPaneDisplayMode.Left && PaneDisplayMode != NavigationViewPaneDisplayMode.LeftCompact));
+            return !topMode && (item?.IsChildItem) is true && (IsPaneOpen || (PaneDisplayMode is not (NavigationViewPaneDisplayMode.Left or NavigationViewPaneDisplayMode.LeftCompact)));
         }
 
         private Point GetCurrentIndicatorPosition()
@@ -1546,7 +1546,7 @@ defaultValue: null,
             if (topMode)
             {
                 double x = fromPosition.X + (direction * length);
-                if (previousItem?.IsVisible == true && previousItem.ActualWidth > 0)
+                if ((previousItem?.IsVisible) is true && previousItem.ActualWidth > 0)
                 {
                     try
                     {
@@ -1564,7 +1564,7 @@ defaultValue: null,
             }
 
             double y = fromPosition.Y + (direction * length);
-            if (previousItem?.IsVisible == true && previousItem.ActualHeight > 0)
+            if ((previousItem?.IsVisible) is true && previousItem.ActualHeight > 0)
             {
                 try
                 {
@@ -1591,7 +1591,7 @@ defaultValue: null,
             if (topMode)
             {
                 double x = toPosition.X - (direction * length);
-                if (targetItem?.IsVisible == true && targetItem.ActualWidth > 0)
+                if ((targetItem?.IsVisible) is true && targetItem.ActualWidth > 0)
                 {
                     try
                     {
@@ -1610,7 +1610,7 @@ defaultValue: null,
             }
 
             double y = toPosition.Y - (direction * length);
-            if (targetItem?.IsVisible == true && targetItem.ActualHeight > 0)
+            if ((targetItem?.IsVisible) is true && targetItem.ActualHeight > 0)
             {
                 try
                 {
@@ -1731,7 +1731,7 @@ defaultValue: null,
 
         private void OnTopOverflowButtonClick(object sender, RoutedEventArgs e)
         {
-            if (_topOverflowButton?.ContextMenu is null || _topOverflowButton.ContextMenu.Items.Count == 0)
+            if (_topOverflowButton?.ContextMenu is null || _topOverflowButton.ContextMenu.Items.Count is 0)
             {
                 return;
             }
@@ -1784,7 +1784,7 @@ defaultValue: null,
                     }
                 }
 
-                if (PaneDisplayMode != NavigationViewPaneDisplayMode.Top || _topOverflowButton is null || _topItemsHost is null)
+                if (PaneDisplayMode is not NavigationViewPaneDisplayMode.Top || _topOverflowButton is null || _topItemsHost is null)
                 {
                     if (_topOverflowButton is not null)
                     {
@@ -1810,7 +1810,7 @@ defaultValue: null,
                 double totalItemWidth = 0.0;
                 foreach (NavigationViewItem navItem in navItems)
                 {
-                    if (navItem.Visibility == Visibility.Visible)
+                    if (navItem.Visibility is Visibility.Visible)
                     {
                         totalItemWidth += GetElementWidth(navItem);
                     }
@@ -1835,7 +1835,7 @@ defaultValue: null,
 
                 foreach (NavigationViewItem navItem in navItems)
                 {
-                    if (navItem.Visibility != Visibility.Visible)
+                    if (navItem.Visibility is not Visibility.Visible)
                     {
                         continue;
                     }
@@ -1855,7 +1855,7 @@ defaultValue: null,
 
                 double overflowOffset = usedWidth;
 
-                if (overflowItems.Count == 0)
+                if (overflowItems.Count is 0)
                 {
                     _topOverflowButton.Visibility = Visibility.Collapsed;
                     SetTopOverflowButtonOffset(0.0);

--- a/Fluence.Wpf/Controls/NavigationViewItem.cs
+++ b/Fluence.Wpf/Controls/NavigationViewItem.cs
@@ -131,7 +131,7 @@ namespace Fluence.Wpf.Controls
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if ((e.Key == Key.Enter || e.Key == Key.Space) && IsEnabled && NavigationView.FromItemContainer(this) is NavigationView nav)
+            if ((e.Key is Key.Enter or Key.Space) && IsEnabled && NavigationView.FromItemContainer(this) is NavigationView nav)
             {
                 nav.InvokeItem(this);
                 e.Handled = true;
@@ -180,7 +180,7 @@ namespace Fluence.Wpf.Controls
         /// </remarks>
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
         {
-            if (!IsEnabled || e.ClickCount != 1)
+            if (!IsEnabled || e.ClickCount is not 1)
             {
                 base.OnPreviewMouseLeftButtonDown(e);
                 return;

--- a/Fluence.Wpf/Controls/NumberBox.cs
+++ b/Fluence.Wpf/Controls/NumberBox.cs
@@ -353,7 +353,7 @@ namespace Fluence.Wpf.Controls
         protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
         {
             base.OnGotKeyboardFocus(e);
-            if (_partTextBox?.IsKeyboardFocusWithin == false)
+            if ((_partTextBox?.IsKeyboardFocusWithin) is false)
             {
                 _ = _partTextBox.Focus();
             }
@@ -363,7 +363,7 @@ namespace Fluence.Wpf.Controls
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
         {
             base.OnPreviewMouseLeftButtonDown(e);
-            if (_partTextBox?.IsKeyboardFocusWithin == false)
+            if ((_partTextBox?.IsKeyboardFocusWithin) is false)
             {
                 _ = _partTextBox.Focus();
             }
@@ -434,18 +434,18 @@ namespace Fluence.Wpf.Controls
 
         private void OnPartTextBoxKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Enter)
+            if (e.Key is Key.Enter)
             {
                 _ = TryParseText();
                 e.Handled = true;
             }
-            else if (e.Key == Key.Up)
+            else if (e.Key is Key.Up)
             {
                 _ = TryParseText();
                 OnUpClick();
                 e.Handled = true;
             }
-            else if (e.Key == Key.Down)
+            else if (e.Key is Key.Down)
             {
                 _ = TryParseText();
                 OnDownClick();

--- a/Fluence.Wpf/Controls/PasswordBox.cs
+++ b/Fluence.Wpf/Controls/PasswordBox.cs
@@ -429,7 +429,7 @@ namespace Fluence.Wpf.Controls
 
         private void OnInnerPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.CapsLock)
+            if (e.Key is Key.CapsLock)
             {
                 _ = Dispatcher.BeginInvoke(new Action(UpdateCapsLockIndicator), DispatcherPriority.Input);
             }
@@ -485,7 +485,7 @@ namespace Fluence.Wpf.Controls
 
         private static int ComputePasswordStrength(string password)
         {
-            if (password.Length == 0)
+            if (password.Length is 0)
             {
                 return 0;
             }
@@ -549,7 +549,7 @@ namespace Fluence.Wpf.Controls
         {
             string brushKey = PasswordStrength <= 1
                 ? "SystemFillColorCriticalBrush"
-                : PasswordStrength == 2
+                : PasswordStrength is 2
                 ? "SystemFillColorCautionBrush"
                 : "SystemFillColorSuccessBrush";
 

--- a/Fluence.Wpf/Controls/PersonPicture.cs
+++ b/Fluence.Wpf/Controls/PersonPicture.cs
@@ -34,8 +34,6 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using WpfGrid = System.Windows.Controls.Grid;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Controls
 {
@@ -46,10 +44,10 @@ namespace Fluence.Wpf.Controls
     /// Visual states: Photo, Initials, NoPhotoOrInitials, Group (CommonStates);
     /// NoBadge, BadgeWithoutImageSource (BadgeStates).
     /// </summary>
-    [TemplatePart(Name = PART_InitialsText, Type = typeof(WpfTextBlock))]
+    [TemplatePart(Name = PART_InitialsText, Type = typeof(System.Windows.Controls.TextBlock))]
     [TemplatePart(Name = PART_ImageEllipse, Type = typeof(Ellipse))]
-    [TemplatePart(Name = PART_BadgeGrid, Type = typeof(WpfGrid))]
-    [TemplatePart(Name = PART_BadgeText, Type = typeof(WpfTextBlock))]
+    [TemplatePart(Name = PART_BadgeGrid, Type = typeof(Grid))]
+    [TemplatePart(Name = PART_BadgeText, Type = typeof(System.Windows.Controls.TextBlock))]
     [TemplateVisualState(GroupName = GroupCommonStates, Name = StatePhoto)]
     [TemplateVisualState(GroupName = GroupCommonStates, Name = StateInitials)]
     [TemplateVisualState(GroupName = GroupCommonStates, Name = StateNoPhotoOrInitials)]
@@ -219,10 +217,10 @@ namespace Fluence.Wpf.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            _initialsText = GetTemplateChild(PART_InitialsText) as WpfTextBlock;
+            _initialsText = GetTemplateChild(PART_InitialsText) as System.Windows.Controls.TextBlock;
             _imageEllipse = GetTemplateChild(PART_ImageEllipse) as Ellipse;
-            _badgeGrid = GetTemplateChild(PART_BadgeGrid) as WpfGrid;
-            _badgeText = GetTemplateChild(PART_BadgeText) as WpfTextBlock;
+            _badgeGrid = GetTemplateChild(PART_BadgeGrid) as Grid;
+            _badgeText = GetTemplateChild(PART_BadgeText) as System.Windows.Controls.TextBlock;
             UpdateVisualState(useTransitions: false);
             UpdateBadge();
         }
@@ -266,7 +264,7 @@ namespace Fluence.Wpf.Controls
                 if (_initialsText is not null)
                 {
                     _initialsText.Text = GlyphPeople;
-                    _initialsText.SetResourceReference(WpfTextBlock.FontFamilyProperty, "FluentFontFamily");
+                    _initialsText.SetResourceReference(System.Windows.Controls.TextBlock.FontFamilyProperty, "FluentFontFamily");
                 }
                 _ = VisualStateManager.GoToState(this, StateGroup, useTransitions);
                 return;
@@ -285,7 +283,7 @@ namespace Fluence.Wpf.Controls
                 if (_initialsText is not null)
                 {
                     _initialsText.Text = initials;
-                    _initialsText.SetResourceReference(WpfTextBlock.FontFamilyProperty, "FluentFontFamily");
+                    _initialsText.SetResourceReference(System.Windows.Controls.TextBlock.FontFamilyProperty, "FluentFontFamily");
                 }
                 _ = VisualStateManager.GoToState(this, StateInitials, useTransitions);
                 return;
@@ -315,7 +313,7 @@ namespace Fluence.Wpf.Controls
                 else if (BadgeNumber > 0)
                 {
                     _badgeText.Text = BadgeNumber > 99 ? "99+" : BadgeNumber.ToString(CultureInfo.CurrentCulture);
-                    _badgeText.SetResourceReference(WpfTextBlock.FontFamilyProperty, "FluentFontFamily");
+                    _badgeText.SetResourceReference(System.Windows.Controls.TextBlock.FontFamilyProperty, "FluentFontFamily");
                     _badgeText.FontSize = BadgeNumber > 9 ? 8 : 10;
                 }
                 else
@@ -346,7 +344,7 @@ namespace Fluence.Wpf.Controls
         /// <summary>
         /// Represents the WPF TextBlock control used to display user initials.
         /// </summary>
-        private WpfTextBlock? _initialsText;
+        private System.Windows.Controls.TextBlock? _initialsText;
 
         /// <summary>
         /// Represents the ellipse shape used to display an image, or null if no ellipse is assigned.
@@ -356,11 +354,11 @@ namespace Fluence.Wpf.Controls
         /// <summary>
         /// Represents the WPF grid used to display the badge, or null if no badge grid is present.
         /// </summary>
-        private WpfGrid? _badgeGrid;
+        private Grid? _badgeGrid;
 
         /// <summary>
         /// Represents the text block used to display a badge in the WPF user interface.
         /// </summary>
-        private WpfTextBlock? _badgeText;
+        private System.Windows.Controls.TextBlock? _badgeText;
     }
 }

--- a/Fluence.Wpf/Controls/PersonPicture.cs
+++ b/Fluence.Wpf/Controls/PersonPicture.cs
@@ -338,7 +338,7 @@ namespace Fluence.Wpf.Controls
             string[] parts = (DisplayName ?? string.Empty).Trim().Split(InitialsSeparators, StringSplitOptions.RemoveEmptyEntries);
             return parts.Length > 1
                 ? (parts[0][0].ToString() + parts[^1][0].ToString()).ToUpperInvariant()
-                : parts.Length == 1
+                : parts.Length is 1
                 ? parts[0][0].ToString().ToUpperInvariant()
                 : null;
         }

--- a/Fluence.Wpf/Controls/ProgressBar.cs
+++ b/Fluence.Wpf/Controls/ProgressBar.cs
@@ -425,10 +425,10 @@ namespace Fluence.Wpf.Controls
             _syncingMode = true;
             try
             {
-                IsIndeterminate = mode == ProgressBarMode.Indeterminate;
-                ShowError = mode == ProgressBarMode.Error;
-                ShowPaused = mode == ProgressBarMode.Paused;
-                _stepMode = mode == ProgressBarMode.StepProgress;
+                IsIndeterminate = mode is ProgressBarMode.Indeterminate;
+                ShowError = mode is ProgressBarMode.Error;
+                ShowPaused = mode is ProgressBarMode.Paused;
+                _stepMode = mode is ProgressBarMode.StepProgress;
             }
             finally
             {

--- a/Fluence.Wpf/Controls/ProgressRing.cs
+++ b/Fluence.Wpf/Controls/ProgressRing.cs
@@ -485,8 +485,8 @@ namespace Fluence.Wpf.Controls
             try
             {
                 ProgressRingState state = (ProgressRingState)e.NewValue;
-                ring.SetCurrentValue(ShowPausedProperty, state == ProgressRingState.Paused);
-                ring.SetCurrentValue(ShowErrorProperty, state == ProgressRingState.Error);
+                ring.SetCurrentValue(ShowPausedProperty, state is ProgressRingState.Paused);
+                ring.SetCurrentValue(ShowErrorProperty, state is ProgressRingState.Error);
             }
             finally
             {

--- a/Fluence.Wpf/Controls/RadioButton.cs
+++ b/Fluence.Wpf/Controls/RadioButton.cs
@@ -74,9 +74,9 @@ namespace Fluence.Wpf.Controls
         /// <summary>
         /// Gets or sets the description text displayed below the radio button content.
         /// </summary>
-        public string Description
+        public string? Description
         {
-            get => (string)GetValue(DescriptionProperty);
+            get => (string?)GetValue(DescriptionProperty);
             set => SetValue(DescriptionProperty, value);
         }
 

--- a/Fluence.Wpf/Controls/RatingControl.cs
+++ b/Fluence.Wpf/Controls/RatingControl.cs
@@ -33,8 +33,6 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using WpfStackPanel = System.Windows.Controls.StackPanel;
-using WpfTextBlock = System.Windows.Controls.TextBlock;
 
 namespace Fluence.Wpf.Controls
 {
@@ -46,8 +44,8 @@ namespace Fluence.Wpf.Controls
     /// Brush states: <c>AccentFillColorDefaultBrush</c> (filled),
     /// <c>TextFillColorSecondaryBrush</c> (unset), <c>TextFillColorDisabledBrush</c> (disabled).
     /// </summary>
-    [TemplatePart(Name = PART_StarsPanel, Type = typeof(WpfStackPanel))]
-    [TemplatePart(Name = PART_Caption, Type = typeof(WpfTextBlock))]
+    [TemplatePart(Name = PART_StarsPanel, Type = typeof(System.Windows.Controls.StackPanel))]
+    [TemplatePart(Name = PART_Caption, Type = typeof(System.Windows.Controls.TextBlock))]
     public class RatingControl : Control
     {
         // Template part names.
@@ -155,8 +153,8 @@ namespace Fluence.Wpf.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            _starsPanel = GetTemplateChild(PART_StarsPanel) as WpfStackPanel;
-            _captionText = GetTemplateChild(PART_Caption) as WpfTextBlock;
+            _starsPanel = GetTemplateChild(PART_StarsPanel) as System.Windows.Controls.StackPanel;
+            _captionText = GetTemplateChild(PART_Caption) as System.Windows.Controls.TextBlock;
             IsEnabledChanged -= OnIsEnabledChanged;
             IsEnabledChanged += OnIsEnabledChanged;
             BuildAndRefreshStars();
@@ -251,7 +249,7 @@ namespace Fluence.Wpf.Controls
             int count = Math.Max(1, MaxRating);
             for (int i = 1; i <= count; i++)
             {
-                WpfTextBlock star = new()
+                System.Windows.Controls.TextBlock star = new()
                 {
                     FontFamily = new FontFamily("Segoe Fluent Icons"),
                     FontSize = 20.0,
@@ -309,7 +307,7 @@ namespace Fluence.Wpf.Controls
             int displayCount = _hoverIndex > 0 ? _hoverIndex : (int)Math.Round(Value, MidpointRounding.ToEven);
             for (int i = 0; i < _starsPanel.Children.Count; i++)
             {
-                if (_starsPanel.Children[i] is not WpfTextBlock star)
+                if (_starsPanel.Children[i] is not System.Windows.Controls.TextBlock star)
                 {
                     continue;
                 }
@@ -318,15 +316,15 @@ namespace Fluence.Wpf.Controls
                 star.Text = filled ? "\uE735" : "\uE734"; // StarFilled / StarEmpty
                 if (!IsEnabled)
                 {
-                    star.SetResourceReference(WpfTextBlock.ForegroundProperty, "TextFillColorDisabledBrush");
+                    star.SetResourceReference(System.Windows.Controls.TextBlock.ForegroundProperty, "TextFillColorDisabledBrush");
                 }
                 else if (filled)
                 {
-                    star.SetResourceReference(WpfTextBlock.ForegroundProperty, "AccentFillColorDefaultBrush");
+                    star.SetResourceReference(System.Windows.Controls.TextBlock.ForegroundProperty, "AccentFillColorDefaultBrush");
                 }
                 else
                 {
-                    star.SetResourceReference(WpfTextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+                    star.SetResourceReference(System.Windows.Controls.TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
                 }
                 star.Cursor = (IsReadOnly || !IsEnabled) ? null : Cursors.Hand;
             }
@@ -346,12 +344,12 @@ namespace Fluence.Wpf.Controls
         /// <summary>
         /// Represents the panel that displays the star rating elements in the WPF user interface.
         /// </summary>
-        private WpfStackPanel? _starsPanel;
+        private System.Windows.Controls.StackPanel? _starsPanel;
 
         /// <summary>
         /// Represents the text block used to display the caption in the WPF user interface.
         /// </summary>
-        private WpfTextBlock? _captionText;
+        private System.Windows.Controls.TextBlock? _captionText;
 
         /// <summary>
         /// Represents the index of the currently hovered item. A value of -1 indicates that no item is hovered.

--- a/Fluence.Wpf/Controls/SplitButton.cs
+++ b/Fluence.Wpf/Controls/SplitButton.cs
@@ -311,7 +311,7 @@ namespace Fluence.Wpf.Controls
                 _popup.StaysOpen = false;
                 _popup.PlacementTarget = this;
                 _popup.Closed += OnPopupClosed;
-                _popup.IsOpen = _secondaryButton is not null && _secondaryButton.IsChecked == true;
+                _popup.IsOpen = _secondaryButton?.IsChecked is true;
             }
         }
 
@@ -362,7 +362,7 @@ namespace Fluence.Wpf.Controls
         private void OnPopupClosed(object? sender, EventArgs e)
         {
             // External click (StaysOpen=false) closed the popup; sync the secondary toggle.
-            if (_secondaryButton is not null && _secondaryButton.IsChecked == true)
+            if (_secondaryButton?.IsChecked is true)
             {
                 _secondaryButton.IsChecked = false;
             }

--- a/Fluence.Wpf/Controls/StackPanel.cs
+++ b/Fluence.Wpf/Controls/StackPanel.cs
@@ -63,13 +63,13 @@ namespace Fluence.Wpf.Controls
             double spacing = Spacing;
             UIElementCollection children = InternalChildren;
             int count = children.Count;
-            if (count == 0)
+            if (count is 0)
             {
                 return new(0, 0);
             }
 
             double totalMain = 0; double maxCross = 0;
-            if (orientation == Orientation.Vertical)
+            if (orientation is Orientation.Vertical)
             {
                 double remainingHeight = constraint.Height;
                 for (int i = 0; i < count; i++)
@@ -122,7 +122,7 @@ namespace Fluence.Wpf.Controls
             double spacing = Spacing;
             UIElementCollection children = InternalChildren;
             int count = children.Count;
-            if (orientation == Orientation.Vertical)
+            if (orientation is Orientation.Vertical)
             {
                 double y = 0.0;
                 for (int i = 0; i < count; i++)

--- a/Fluence.Wpf/Controls/TeachingTip.cs
+++ b/Fluence.Wpf/Controls/TeachingTip.cs
@@ -375,7 +375,7 @@ namespace Fluence.Wpf.Controls
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {
             base.OnPreviewKeyDown(e);
-            if (!e.Handled && e.Key == Key.Escape && IsOpen)
+            if (!e.Handled && e.Key is Key.Escape && IsOpen)
             {
                 SetCurrentValue(IsOpenProperty, value: false);
                 e.Handled = true;
@@ -422,7 +422,7 @@ namespace Fluence.Wpf.Controls
         private static void OnPlacementInputChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             TeachingTip tip = (TeachingTip)d;
-            if (tip.HostPopup?.IsOpen == true)
+            if ((tip.HostPopup?.IsOpen) is true)
             {
                 tip.ApplyPlacement(tip.HostPopup);
             }
@@ -463,7 +463,7 @@ namespace Fluence.Wpf.Controls
         /// <returns>The resolved placement mode.</returns>
         private static TeachingTipPlacementMode ResolvePlacement(TeachingTipPlacementMode preferred)
         {
-            return preferred == TeachingTipPlacementMode.Auto
+            return preferred is TeachingTipPlacementMode.Auto
                 ? TeachingTipPlacementMode.Bottom
                 : preferred;
         }
@@ -513,7 +513,7 @@ namespace Fluence.Wpf.Controls
         /// </summary>
         private void ClosePopup()
         {
-            if (HostPopup?.IsOpen == true)
+            if ((HostPopup?.IsOpen) is true)
             {
                 HostPopup.IsOpen = false;
             }
@@ -536,7 +536,7 @@ namespace Fluence.Wpf.Controls
             {
                 popup.PlacementTarget = target;
                 TeachingTipPlacementMode resolved = ResolvePlacement(PreferredPlacement);
-                if (resolved == TeachingTipPlacementMode.Center)
+                if (resolved is TeachingTipPlacementMode.Center)
                 {
                     popup.CustomPopupPlacementCallback = null;
                     popup.Placement = PlacementMode.Center;
@@ -552,7 +552,7 @@ namespace Fluence.Wpf.Controls
             else
             {
                 popup.PlacementTarget = ResolveFallbackPlacementTarget();
-                if (PreferredPlacement == TeachingTipPlacementMode.Auto)
+                if (PreferredPlacement is TeachingTipPlacementMode.Auto)
                 {
                     popup.CustomPopupPlacementCallback = GetBottomRightPlacements;
                     popup.Placement = PlacementMode.Custom;
@@ -694,7 +694,7 @@ namespace Fluence.Wpf.Controls
         {
             ActionButtonClick?.Invoke(this, EventArgs.Empty);
             ICommand? command = ActionButtonCommand;
-            if (command?.CanExecute(ActionButtonCommandParameter) == true)
+            if ((command?.CanExecute(ActionButtonCommandParameter)) is true)
             {
                 command.Execute(ActionButtonCommandParameter);
             }

--- a/Fluence.Wpf/Controls/TextBox.cs
+++ b/Fluence.Wpf/Controls/TextBox.cs
@@ -332,7 +332,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (ValidationState != ValidationState.None)
+            if (ValidationState is not ValidationState.None)
             {
                 string message = !string.IsNullOrWhiteSpace(ValidationMessage) ? ValidationMessage : HelperText;
                 helper.Text = message;

--- a/Fluence.Wpf/Controls/TimePicker.cs
+++ b/Fluence.Wpf/Controls/TimePicker.cs
@@ -330,7 +330,7 @@ defaultValue: null,
         private static int GetTwelveHourDisplayHour(int hour)
         {
             int displayHour = hour % 12;
-            return displayHour == 0 ? 12 : displayHour;
+            return displayHour is 0 ? 12 : displayHour;
         }
 
         /// <summary>
@@ -452,19 +452,19 @@ defaultValue: null,
         /// <param name="e">The event data.</param>
         private void OnPopupPreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Handled || _popup?.IsOpen != true)
+            if (e.Handled || (_popup?.IsOpen) is not true)
             {
                 return;
             }
 
-            if (e.Key == Key.Escape)
+            if (e.Key is Key.Escape)
             {
                 ClosePopup();
                 e.Handled = true;
                 return;
             }
 
-            if (e.Key == Key.Enter)
+            if (e.Key is Key.Enter)
             {
                 IInputElement? focused = Keyboard.FocusedElement;
                 if (ReferenceEquals(focused, _acceptButton) || ReferenceEquals(focused, _cancelButton))
@@ -484,7 +484,7 @@ defaultValue: null,
         /// </summary>
         private void MoveFocusIntoPopup()
         {
-            if (_popup?.IsOpen != true)
+            if ((_popup?.IsOpen) is not true)
             {
                 return;
             }
@@ -514,7 +514,7 @@ defaultValue: null,
         {
             foreach (Selector? column in (Selector?[])[_hourList, _minuteList, _periodList])
             {
-                if (column is not null && column.Visibility == Visibility.Visible)
+                if (column?.Visibility is Visibility.Visible)
                 {
                     return column;
                 }
@@ -603,7 +603,7 @@ defaultValue: null,
 
         private void ClosePopup()
         {
-            if (_popup?.IsOpen == true)
+            if ((_popup?.IsOpen) is true)
             {
                 // Closing through the control's own pipeline must not arm the light-dismiss
                 // reopen lockout; Popup.Closed is raised synchronously from the set below.
@@ -646,7 +646,7 @@ defaultValue: null,
         private bool GetPendingIsPm()
         {
             return _periodList?.SelectedIndex >= 0
-                ? _periodList.SelectedIndex == 1
+                ? _periodList.SelectedIndex is 1
                 : _flyoutBaseTime.Hours >= 12;
         }
 

--- a/Fluence.Wpf/Controls/TimePicker.cs
+++ b/Fluence.Wpf/Controls/TimePicker.cs
@@ -408,7 +408,7 @@ defaultValue: null,
         /// </summary>
         private bool IsWithinLightDismissReopenLockout()
         {
-            return _lastLightDismissTick.HasValue
+            return _lastLightDismissTick is not null
                 && unchecked(Environment.TickCount - _lastLightDismissTick.Value) < LightDismissReopenLockoutMilliseconds;
         }
 
@@ -664,22 +664,22 @@ defaultValue: null,
             CultureInfo culture = CultureInfo.CurrentCulture;
             TimeSpan? selectedTime = SelectedTime;
             bool twentyFourHour = IsTwentyFourHourClock;
-            int hour = selectedTime.HasValue ? ((selectedTime.Value.Hours % 24) + 24) % 24 : 0;
-            int minute = selectedTime.HasValue ? ((selectedTime.Value.Minutes % 60) + 60) % 60 : 0;
+            int hour = selectedTime is not null ? ((selectedTime.Value.Hours % 24) + 24) % 24 : 0;
+            int minute = selectedTime is not null ? ((selectedTime.Value.Minutes % 60) + 60) % 60 : 0;
 
-            string hourText = !selectedTime.HasValue
+            string hourText = selectedTime is null
                 ? string.Empty
                 : twentyFourHour
                     ? hour.ToString(culture)
                     : GetTwelveHourDisplayHour(hour).ToString(culture);
             _hourSegmentText?.SetCurrentValue(System.Windows.Controls.TextBlock.TextProperty, hourText);
 
-            string minuteText = selectedTime.HasValue
+            string minuteText = selectedTime is not null
                 ? minute.ToString("00", culture)
                 : string.Empty;
             _minuteSegmentText?.SetCurrentValue(System.Windows.Controls.TextBlock.TextProperty, minuteText);
 
-            string periodText = selectedTime.HasValue && !twentyFourHour
+            string periodText = selectedTime is not null && !twentyFourHour
                 ? GetPeriodDesignator(hour, culture)
                 : string.Empty;
             _periodSegmentText?.SetCurrentValue(System.Windows.Controls.TextBlock.TextProperty, periodText);

--- a/Fluence.Wpf/Controls/TitleBar.cs
+++ b/Fluence.Wpf/Controls/TitleBar.cs
@@ -30,7 +30,6 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using WpfButton = System.Windows.Controls.Button;
 
 namespace Fluence.Wpf.Controls
 {
@@ -45,8 +44,8 @@ namespace Fluence.Wpf.Controls
     /// <see cref="BackRequested"/> and <see cref="PaneToggleRequested"/> events or the command
     /// properties <see cref="BackCommand"/> and <see cref="PaneToggleCommand"/>.
     /// </remarks>
-    [TemplatePart(Name = PART_BackButton, Type = typeof(WpfButton))]
-    [TemplatePart(Name = PART_PaneToggleButton, Type = typeof(WpfButton))]
+    [TemplatePart(Name = PART_BackButton, Type = typeof(System.Windows.Controls.Button))]
+    [TemplatePart(Name = PART_PaneToggleButton, Type = typeof(System.Windows.Controls.Button))]
     [TemplatePart(Name = "PART_IconPresenter", Type = typeof(ContentPresenter))]
     [TemplatePart(Name = "PART_TitleText", Type = typeof(TextBlock))]
     [TemplatePart(Name = "PART_SubtitleText", Type = typeof(TextBlock))]
@@ -371,8 +370,8 @@ namespace Fluence.Wpf.Controls
 
             base.OnApplyTemplate();
 
-            _backButton = GetTemplateChild(PART_BackButton) as WpfButton;
-            _paneToggleButton = GetTemplateChild(PART_PaneToggleButton) as WpfButton;
+            _backButton = GetTemplateChild(PART_BackButton) as System.Windows.Controls.Button;
+            _paneToggleButton = GetTemplateChild(PART_PaneToggleButton) as System.Windows.Controls.Button;
 
             _backButton?.Click += OnBackButtonClick;
             _paneToggleButton?.Click += OnPaneToggleButtonClick;
@@ -596,8 +595,8 @@ namespace Fluence.Wpf.Controls
 
         #region Private fields
 
-        private WpfButton? _backButton;
-        private WpfButton? _paneToggleButton;
+        private System.Windows.Controls.Button? _backButton;
+        private System.Windows.Controls.Button? _paneToggleButton;
         private bool _isBackCommandSubscribed;
         private bool _isPaneToggleCommandSubscribed;
 

--- a/Fluence.Wpf/Controls/TitleBar.cs
+++ b/Fluence.Wpf/Controls/TitleBar.cs
@@ -539,7 +539,7 @@ namespace Fluence.Wpf.Controls
 
         private static bool CanExecuteCommand(ICommand command, object parameter)
         {
-            return command?.CanExecute(parameter) != false;
+            return (command?.CanExecute(parameter)) is not false;
         }
 
         private static void SubscribeCommand(ICommand? command, EventHandler handler)

--- a/Fluence.Wpf/Controls/ToggleSwitch.cs
+++ b/Fluence.Wpf/Controls/ToggleSwitch.cs
@@ -261,7 +261,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            CompleteThumbInteraction(IsChecked != true);
+            CompleteThumbInteraction(IsChecked is not true);
             e.Handled = true;
         }
 
@@ -312,7 +312,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (Mouse.LeftButton == MouseButtonState.Released)
+            if (Mouse.LeftButton is MouseButtonState.Released)
             {
                 CompleteThumbInteraction(ResolveThumbInteractionCheckedState());
                 return;
@@ -324,7 +324,7 @@ namespace Fluence.Wpf.Controls
         private bool ResolveThumbInteractionCheckedState()
         {
             return _dragDistance <= DragDistanceThreshold
-                ? IsChecked != true
+                ? IsChecked is not true
                 : (_knobTranslate?.X ?? KnobOffOffset) >= DragCommitOffset;
         }
 
@@ -339,7 +339,7 @@ namespace Fluence.Wpf.Controls
 
         private void CompleteThumbInteraction(bool nextChecked)
         {
-            bool currentChecked = IsChecked == true;
+            bool currentChecked = IsChecked is true;
             _pendingClick = false;
             _dragStarted = false;
             _dragDistance = 0.0;
@@ -360,7 +360,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            double targetOffset = IsChecked == true ? KnobOnOffset : KnobOffOffset;
+            double targetOffset = IsChecked is true ? KnobOnOffset : KnobOffOffset;
             if (!useAnimation)
             {
                 SetKnobOffset(targetOffset);

--- a/Fluence.Wpf/Controls/TreeView.cs
+++ b/Fluence.Wpf/Controls/TreeView.cs
@@ -121,7 +121,7 @@ namespace Fluence.Wpf.Controls
         {
             base.OnSelectedItemChanged(e);
 
-            if (SelectionMode == TreeViewSelectionMode.Single)
+            if (SelectionMode is TreeViewSelectionMode.Single)
             {
                 _selectedItems.Clear();
                 if (e.NewValue is not null)
@@ -129,7 +129,7 @@ namespace Fluence.Wpf.Controls
                     _ = _selectedItems.Add(e.NewValue);
                 }
             }
-            else if (SelectionMode == TreeViewSelectionMode.None)
+            else if (SelectionMode is TreeViewSelectionMode.None)
             {
                 _selectedItems.Clear();
             }
@@ -138,7 +138,7 @@ namespace Fluence.Wpf.Controls
         /// <inheritdoc />
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {
-            if (e.Key == Key.Space && ToggleMultipleSelectionItem(e.OriginalSource as DependencyObject))
+            if (e.Key is Key.Space && ToggleMultipleSelectionItem(e.OriginalSource as DependencyObject))
             {
                 e.Handled = true;
                 return;
@@ -154,10 +154,10 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (SelectionMode == TreeViewSelectionMode.None)
+            if (SelectionMode is TreeViewSelectionMode.None)
             {
                 _selectedItems.Clear();
-                if (item.IsSelectionChecked != false)
+                if (item.IsSelectionChecked is not false)
                 {
                     item.SetCurrentValue(TreeViewItem.IsSelectionCheckedProperty, value: false);
                 }
@@ -167,10 +167,10 @@ namespace Fluence.Wpf.Controls
 
             object selectedItem = GetSelectedItemValue(item);
 
-            if (SelectionMode == TreeViewSelectionMode.Single)
+            if (SelectionMode is TreeViewSelectionMode.Single)
             {
                 _selectedItems.Clear();
-                if (isSelected == true)
+                if (isSelected is true)
                 {
                     _ = _selectedItems.Add(selectedItem);
                     item.SetCurrentValue(System.Windows.Controls.TreeViewItem.IsSelectedProperty, value: true);
@@ -198,11 +198,11 @@ namespace Fluence.Wpf.Controls
 
         internal void ApplySelectionModeToItems()
         {
-            if (SelectionMode == TreeViewSelectionMode.None)
+            if (SelectionMode is TreeViewSelectionMode.None)
             {
                 _selectedItems.Clear();
             }
-            else if (SelectionMode == TreeViewSelectionMode.Single)
+            else if (SelectionMode is TreeViewSelectionMode.Single)
             {
                 _selectedItems.Clear();
                 if (SelectedItem is not null)
@@ -224,7 +224,7 @@ namespace Fluence.Wpf.Controls
 
         private bool ToggleMultipleSelectionItem(DependencyObject? source)
         {
-            if (SelectionMode != TreeViewSelectionMode.Multiple)
+            if (SelectionMode is not TreeViewSelectionMode.Multiple)
             {
                 return false;
             }
@@ -235,7 +235,7 @@ namespace Fluence.Wpf.Controls
                 return false;
             }
 
-            item.SetCurrentValue(TreeViewItem.IsSelectionCheckedProperty, item.IsSelectionChecked != true);
+            item.SetCurrentValue(TreeViewItem.IsSelectionCheckedProperty, item.IsSelectionChecked is not true);
             return true;
         }
 
@@ -275,7 +275,7 @@ namespace Fluence.Wpf.Controls
                 }
 
                 TreeView? treeView = FindOwningTreeView(container);
-                if (treeView is not null && treeView.SelectionMode != TreeViewSelectionMode.Multiple)
+                if (treeView is not null && treeView.SelectionMode is not TreeViewSelectionMode.Multiple)
                 {
                     container.SetCurrentValue(TreeViewItem.IsSelectionCheckedProperty, value: false);
                 }
@@ -341,7 +341,7 @@ namespace Fluence.Wpf.Controls
                 }
 
                 childCount++;
-                if (container.IsSelectionChecked == true)
+                if (container.IsSelectionChecked is true)
                 {
                     checkedCount++;
                 }
@@ -355,7 +355,7 @@ namespace Fluence.Wpf.Controls
             {
                 0 => false,
                 _ when checkedCount == childCount => true,
-                _ when checkedCount == 0 && !hasPartialChild => false,
+                _ when checkedCount is 0 && !hasPartialChild => false,
                 _ => null,
             };
         }
@@ -378,7 +378,7 @@ namespace Fluence.Wpf.Controls
                     continue;
                 }
 
-                if (container.IsSelectionChecked == true)
+                if (container.IsSelectionChecked is true)
                 {
                     object selectedItem = GetSelectedItemValue(container);
                     if (!_selectedItems.Contains(selectedItem))

--- a/Fluence.Wpf/Controls/TreeViewItem.cs
+++ b/Fluence.Wpf/Controls/TreeViewItem.cs
@@ -107,11 +107,11 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (owner.SelectionMode == TreeViewSelectionMode.None)
+            if (owner.SelectionMode is TreeViewSelectionMode.None)
             {
                 SetCurrentValue(IsSelectedProperty, value: false);
             }
-            else if (owner.SelectionMode == TreeViewSelectionMode.Multiple)
+            else if (owner.SelectionMode is TreeViewSelectionMode.Multiple)
             {
                 SetCurrentValue(IsSelectionCheckedProperty, value: true);
             }
@@ -120,7 +120,7 @@ namespace Fluence.Wpf.Controls
         /// <inheritdoc />
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {
-            if (e.Key == Key.Space && ToggleMultipleSelectionFromKeyboard())
+            if (e.Key is Key.Space && ToggleMultipleSelectionFromKeyboard())
             {
                 e.Handled = true;
                 return;
@@ -132,7 +132,7 @@ namespace Fluence.Wpf.Controls
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if (e.Key == Key.Space && ToggleMultipleSelectionFromKeyboard())
+            if (e.Key is Key.Space && ToggleMultipleSelectionFromKeyboard())
             {
                 e.Handled = true;
                 return;
@@ -148,7 +148,7 @@ namespace Fluence.Wpf.Controls
                 return;
             }
 
-            if (owner.SelectionMode != TreeViewSelectionMode.Multiple && IsSelectionChecked != false)
+            if (owner.SelectionMode is not TreeViewSelectionMode.Multiple && IsSelectionChecked is not false)
             {
                 SetCurrentValue(IsSelectionCheckedProperty, value: false);
             }
@@ -168,9 +168,9 @@ namespace Fluence.Wpf.Controls
             }
 
             bool? isChecked = (bool?)e.NewValue;
-            if (owner.SelectionMode != TreeViewSelectionMode.Multiple)
+            if (owner.SelectionMode is not TreeViewSelectionMode.Multiple)
             {
-                if (isChecked != false && !item._isKeyboardSelectionToggle)
+                if (isChecked is not false && !item._isKeyboardSelectionToggle)
                 {
                     item.SetCurrentValue(IsSelectionCheckedProperty, value: false);
                 }
@@ -187,17 +187,17 @@ namespace Fluence.Wpf.Controls
             if (owner is null)
             {
                 CheckBox? selectionCheckBox = GetTemplateChild(SelectionCheckBoxPart) as CheckBox;
-                if (selectionCheckBox?.Visibility != Visibility.Visible)
+                if ((selectionCheckBox?.Visibility) is not Visibility.Visible)
                 {
                     return false;
                 }
             }
-            else if (owner.SelectionMode != TreeViewSelectionMode.Multiple)
+            else if (owner.SelectionMode is not TreeViewSelectionMode.Multiple)
             {
                 return false;
             }
 
-            bool nextState = IsSelectionChecked != true;
+            bool nextState = IsSelectionChecked is not true;
             _isKeyboardSelectionToggle = true;
             try
             {

--- a/Fluence.Wpf/Controls/WindowPolicy.cs
+++ b/Fluence.Wpf/Controls/WindowPolicy.cs
@@ -115,7 +115,7 @@ namespace Fluence.Wpf.Controls
         /// <see cref="WindowChrome.GlassFrameThickness"/>.</returns>
         internal static Thickness GetGlassFrameThickness(BackdropType backdrop, bool hasShadow)
         {
-            return backdrop != BackdropType.None || hasShadow
+            return backdrop is not BackdropType.None || hasShadow
                 ? new Thickness(-1)
                 : new Thickness(0.00001);
         }
@@ -139,9 +139,9 @@ namespace Fluence.Wpf.Controls
         /// </returns>
         internal static Thickness GetResizeBorderThickness(WindowState windowState, ResizeMode resizeMode)
         {
-            return windowState == WindowState.Maximized
-                   || resizeMode == ResizeMode.NoResize
-                   || resizeMode == ResizeMode.CanMinimize
+            return windowState is WindowState.Maximized
+                || resizeMode is ResizeMode.NoResize
+                or ResizeMode.CanMinimize
                 ? new Thickness(0)
                 : new Thickness(4);
         }
@@ -191,7 +191,7 @@ namespace Fluence.Wpf.Controls
             WindowCapabilities capabilities,
             Color accentColor)
         {
-            Thickness templateBorderThickness = windowState == WindowState.Maximized
+            Thickness templateBorderThickness = windowState is WindowState.Maximized
                 ? new Thickness(0)
                 : new Thickness(2);
 
@@ -301,10 +301,10 @@ namespace Fluence.Wpf.Controls
             Color fallbackBackgroundColor)
         {
             BackdropType effectiveBackdrop = ResolveEffectiveBackdrop(requestedBackdrop, capabilities);
-            bool isDark = resolvedTheme == ApplicationTheme.Dark;
+            bool isDark = resolvedTheme is ApplicationTheme.Dark;
 
             // None path: solid background, default caption color, explicit DWMSBT_NONE on 22H2+.
-            if (effectiveBackdrop == BackdropType.None)
+            if (effectiveBackdrop is BackdropType.None)
             {
                 int? clearedSystemBackdrop = capabilities.SupportsSystemBackdropType
                     ? NativeConstants.DWMSBT_NONE
@@ -321,7 +321,7 @@ namespace Fluence.Wpf.Controls
             }
 
             // Mica on pre-22H2 Win11: legacy DWMWA_MICA_EFFECT; no DWMWA_SYSTEMBACKDROP_TYPE.
-            if (effectiveBackdrop == BackdropType.Mica
+            if (effectiveBackdrop is BackdropType.Mica
                 && !capabilities.SupportsSystemBackdropType
                 && capabilities.SupportsMicaEffect)
             {

--- a/Fluence.Wpf/Fluence.Wpf.csproj
+++ b/Fluence.Wpf/Fluence.Wpf.csproj
@@ -63,5 +63,9 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.26100.0' or '$(TargetFramework)' == 'net10.0-windows10.0.26100.0'">
+    <NoWarn>$(NoWarn);RCS1255</NoWarn>
+  </PropertyGroup>
+
 
 </Project>

--- a/Fluence.Wpf/Fluence.Wpf.csproj
+++ b/Fluence.Wpf/Fluence.Wpf.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Fluence.Wpf</RootNamespace>
     <AssemblyName>Fluence.Wpf</AssemblyName>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <NoWarn>$(NoWarn);SYSLIB1045;IDE0330;S1244;VSTHRD001</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB1045;S1244;VSTHRD001</NoWarn>
     <DocumentationFile Condition="'$(TargetFramework)' != ''">bin/$(Configuration)/$(TargetFramework)/Fluence.Wpf.xml</DocumentationFile>
     <Description>Windows 11 Fluent Design controls and theming for WPF (.NET Framework 4.7.2 and .NET 10)</Description>
     <Product>Fluence.Wpf</Product>

--- a/Fluence.Wpf/Helpers/GridLengthAnimation.cs
+++ b/Fluence.Wpf/Helpers/GridLengthAnimation.cs
@@ -138,7 +138,7 @@ namespace Fluence.Wpf.Helpers
                 throw new ArgumentNullException(nameof(animationClock));
             }
             GridLength fromLength = From; double fromValue;
-            if (fromLength.GridUnitType == GridUnitType.Auto)
+            if (fromLength.GridUnitType is GridUnitType.Auto)
             {
                 GridLength originLength = defaultOriginValue is not GridLength origin
                     ? new GridLength(0d, GridUnitType.Pixel)

--- a/Fluence.Wpf/Helpers/RegistryHelper.cs
+++ b/Fluence.Wpf/Helpers/RegistryHelper.cs
@@ -38,19 +38,19 @@ namespace Fluence.Wpf.Helpers
         internal static bool GetAppsUseLightTheme()
         {
             using RegistryKey? key = Registry.CurrentUser.OpenSubKey(NativeConstants.PersonalizeRegistryPath);
-            return key?.GetValue(NativeConstants.AppsUseLightTheme) is not int intValue || intValue != 0;
+            return key?.GetValue(NativeConstants.AppsUseLightTheme) is not int intValue || intValue is not 0;
         }
 
         internal static bool GetSystemUsesLightTheme()
         {
             using RegistryKey? key = Registry.CurrentUser.OpenSubKey(NativeConstants.PersonalizeRegistryPath);
-            return key?.GetValue(NativeConstants.SystemUsesLightTheme) is not int intValue || intValue != 0;
+            return key?.GetValue(NativeConstants.SystemUsesLightTheme) is not int intValue || intValue is not 0;
         }
 
         internal static bool GetColorPrevalence()
         {
             using RegistryKey? key = Registry.CurrentUser.OpenSubKey(NativeConstants.DwmRegistryPath);
-            return key?.GetValue(NativeConstants.ColorPrevalence) is not int intValue || intValue != 0;
+            return key?.GetValue(NativeConstants.ColorPrevalence) is not int intValue || intValue is not 0;
         }
 
         internal static bool TryGetAccentPalette(out Color[]? palette)
@@ -66,7 +66,7 @@ namespace Fluence.Wpf.Helpers
                     byte g = bytes[offset + 1];
                     byte b = bytes[offset + 2];
                     byte a = bytes[offset + 3];
-                    palette[i] = Color.FromArgb(a == 0 ? (byte)255 : a, r, g, b);
+                    palette[i] = Color.FromArgb(a is 0 ? (byte)255 : a, r, g, b);
                 }
                 return true;
             }
@@ -84,7 +84,7 @@ namespace Fluence.Wpf.Helpers
                 byte b = (byte)((color >> 16) & 0xFF);
                 byte g = (byte)((color >> 8) & 0xFF);
                 byte r = (byte)(color & 0xFF);
-                return Color.FromArgb(a == 0 ? (byte)255 : a, r, g, b);
+                return Color.FromArgb(a is 0 ? (byte)255 : a, r, g, b);
             }
             return Color.FromRgb(0x00, 0x78, 0xD4);
         }
@@ -129,7 +129,7 @@ namespace Fluence.Wpf.Helpers
                 byte b = (byte)((raw >> 16) & 0xFF);
                 byte g = (byte)((raw >> 8) & 0xFF);
                 byte r = (byte)(raw & 0xFF);
-                color = Color.FromArgb(a == 0 ? (byte)255 : a, r, g, b);
+                color = Color.FromArgb(a is 0 ? (byte)255 : a, r, g, b);
                 return true;
             }
             color = default;
@@ -153,7 +153,7 @@ namespace Fluence.Wpf.Helpers
                 byte b = (byte)((raw >> 16) & 0xFF);
                 byte g = (byte)((raw >> 8) & 0xFF);
                 byte r = (byte)(raw & 0xFF);
-                color = Color.FromArgb(a == 0 ? (byte)255 : a, r, g, b);
+                color = Color.FromArgb(a is 0 ? (byte)255 : a, r, g, b);
                 return true;
             }
             color = default;
@@ -179,7 +179,7 @@ namespace Fluence.Wpf.Helpers
                 byte r = (byte)((raw >> 16) & 0xFF);
                 byte g = (byte)((raw >> 8) & 0xFF);
                 byte b = (byte)(raw & 0xFF);
-                colorizationColor = Color.FromArgb(a == 0 ? (byte)255 : a, r, g, b);
+                colorizationColor = Color.FromArgb(a is 0 ? (byte)255 : a, r, g, b);
                 balance = balanceInt;
                 return true;
             }

--- a/Fluence.Wpf/Helpers/SnapLayoutHelper.cs
+++ b/Fluence.Wpf/Helpers/SnapLayoutHelper.cs
@@ -57,7 +57,7 @@ namespace Fluence.Wpf.Helpers
         internal static bool IsSnapLayoutEnabled()
         {
             using RegistryKey? key = Registry.CurrentUser.OpenSubKey(NativeConstants.ExplorerAdvancedRegistryPath);
-            return key?.GetValue(NativeConstants.EnableSnapAssistFlyout) is not int value || value != 0;
+            return key?.GetValue(NativeConstants.EnableSnapAssistFlyout) is not int value || value is not 0;
         }
     }
 }

--- a/Fluence.Wpf/Native/NativeMethods.cs
+++ b/Fluence.Wpf/Native/NativeMethods.cs
@@ -305,7 +305,7 @@ namespace Fluence.Wpf.Native
         public static bool SetWindowAttribute(IntPtr hwnd, int attribute, int value)
         {
             int result = DwmSetWindowAttribute(hwnd, attribute, ref value, sizeof(int));
-            return result == 0;
+            return result is 0;
         }
 
         /// <summary>Sets the rounded-corner preference (one of the <c>DWMWCP_*</c> values).</summary>
@@ -385,7 +385,7 @@ namespace Fluence.Wpf.Native
                 return 0;
             }
             int result = DwmGetWindowAttribute(hwnd, NativeConstants.DWMWA_CLOAKED, out int cloaked, sizeof(int));
-            return result == 0 ? cloaked : 0;
+            return result is 0 ? cloaked : 0;
         }
 
         /// <summary>Toggles the legacy Windows 11 21H2 Mica effect (<c>DWMWA_MICA_EFFECT</c>).</summary>
@@ -448,7 +448,7 @@ namespace Fluence.Wpf.Native
         {
             MARGINS margins = new() { cxLeftWidth = -1, cxRightWidth = -1, cyTopHeight = -1, cyBottomHeight = -1 };
             int result = DwmExtendFrameIntoClientArea(hwnd, ref margins);
-            return result == 0;
+            return result is 0;
         }
 
         /// <summary>
@@ -470,7 +470,7 @@ namespace Fluence.Wpf.Native
         public static bool IsCompositionEnabled()
         {
             int result = DwmIsCompositionEnabled(out bool enabled);
-            return result == 0 && enabled;
+            return result is 0 && enabled;
         }
 
         /// <summary>Rounds the window corners with the full radius (<c>DWMWCP_ROUND</c>).</summary>
@@ -547,7 +547,7 @@ namespace Fluence.Wpf.Native
             };
 
             int result = RtlGetVersion(ref versionInfo);
-            return result != 0
+            return result is not 0
                 ? throw new InvalidOperationException("RtlGetVersion failed.")
                 : new Version(
                     versionInfo.MajorVersion,

--- a/Fluence.Wpf/SystemThemeWatcher.cs
+++ b/Fluence.Wpf/SystemThemeWatcher.cs
@@ -234,7 +234,7 @@ namespace Fluence.Wpf
             {
                 // Settings messages arrive on the HWND hook path. Re-enter through the
                 // Dispatcher so ResourceDictionary mutation stays on the WPF UI thread.
-                if (ApplicationThemeManager.CurrentTheme != ApplicationTheme.Auto)
+                if (ApplicationThemeManager.CurrentTheme is not ApplicationTheme.Auto)
                 {
                     ApplicationAccentColorManager.RefreshAccent();
                 }

--- a/Fluence.Wpf/TabKeyboardNavigation.cs
+++ b/Fluence.Wpf/TabKeyboardNavigation.cs
@@ -50,13 +50,13 @@ namespace Fluence.Wpf
 
         private static void OnTabItemPreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
-            if (e.Key != System.Windows.Input.Key.Tab)
+            if (e.Key is not System.Windows.Input.Key.Tab)
             {
                 return;
             }
 
             System.Windows.Input.ModifierKeys modifiers = System.Windows.Input.Keyboard.Modifiers;
-            if ((modifiers & ~System.Windows.Input.ModifierKeys.Shift) != System.Windows.Input.ModifierKeys.None)
+            if ((modifiers & ~System.Windows.Input.ModifierKeys.Shift) is not System.Windows.Input.ModifierKeys.None)
             {
                 return;
             }

--- a/Fluence.Wpf/Theming/ColorMap.cs
+++ b/Fluence.Wpf/Theming/ColorMap.cs
@@ -58,7 +58,7 @@ namespace Fluence.Wpf.Theming
         internal static Dictionary<string, Color> Build(ApplicationTheme theme, AccentPalette p, bool deterministicChrome = false)
         {
             Dictionary<string, Color> m = BaseColorTables.Load(theme);
-            bool dark = theme == ApplicationTheme.Dark;
+            bool dark = theme is ApplicationTheme.Dark;
 
             // Raw ramp (theme-independent keys)
             m["SystemAccentColor"] = p.Accent;
@@ -99,7 +99,7 @@ namespace Fluence.Wpf.Theming
             m["AccentFillColorSelectedTextBackground"] = p.Accent;
 
             // Disabled accent + attention (from UpdateDisabledAccentFill / UpdateSystemAttentionFill), skip for HC
-            if (theme != ApplicationTheme.HighContrast)
+            if (theme is not ApplicationTheme.HighContrast)
             {
                 m["AccentFillColorDisabled"] = dark ? Color.FromArgb(0x28, 0xFF, 0xFF, 0xFF) : Color.FromArgb(0x37, 0, 0, 0);
                 m["SystemFillColorAttention"] = dark ? p.Light2 : p.Accent;

--- a/Fluence.Wpf/Theming/SpecialBrushes.cs
+++ b/Fluence.Wpf/Theming/SpecialBrushes.cs
@@ -62,7 +62,7 @@ namespace Fluence.Wpf.Theming
             // Ported verbatim from Theme.Light/Dark.xaml accent-brush overrides (and the legacy
             // UpdateResources isDark branch). HighContrast keeps these computed values: the legacy
             // C# accent overlay took precedence over the HC XAML for accent-derived brush keys.
-            bool dark = theme == ApplicationTheme.Dark;
+            bool dark = theme is ApplicationTheme.Dark;
             dict["SystemAccentColorPrimaryBrush"] = Solid(dark ? colors["SystemAccentColorDark3"] : colors["SystemAccentColorDark2"]);
             dict["SystemAccentColorSecondaryBrush"] = Solid(colors["SystemAccentColorDark3"]);
             dict["SystemAccentColorTertiaryBrush"] = Solid(dark ? colors["SystemAccentColorLight2"] : colors["SystemAccentColorDark1"]);
@@ -80,7 +80,7 @@ namespace Fluence.Wpf.Theming
             // SystemColors in every theme, not the computed palette.
             AddSystemColorAliases(dict);
 
-            if (theme == ApplicationTheme.HighContrast)
+            if (theme is ApplicationTheme.HighContrast)
             {
                 AddHighContrastBrushes(dict);
                 return;

--- a/Fluence.Wpf/Theming/ThemeResolver.cs
+++ b/Fluence.Wpf/Theming/ThemeResolver.cs
@@ -45,7 +45,7 @@ namespace Fluence.Wpf.Theming
         /// <param name="theme">The theme to resolve.</param>
         internal static ApplicationTheme Resolve(ApplicationTheme theme)
         {
-            if (theme != ApplicationTheme.Auto)
+            if (theme is not ApplicationTheme.Auto)
             {
                 return theme;
             }


### PR DESCRIPTION
﻿## Summary

Does what it says on the tin.

## Verification

- [x] `dotnet build Fluence.Wpf.sln -c Release --no-restore -v minimal` (0 errors / 0 warnings, both TFMs)
- [x] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net472 --no-build`
- [x] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net10.0-windows10.0.26100.0 --no-build`
- [x] `pwsh .claude/hooks/post-tool-util.ps1 -CheckAll` passes (UTF-8 BOM, LF, banned APIs, no hard-coded hex or em/en dashes).
- [x] Visual pass completed in `Fluence.Wpf.Demo` for Light, Dark, High Contrast, accent swap, and relevant backdrop.

## Checklist

- [x] Public API changes have XML docs and tests; the test count does not drop below the baseline.
- [x] Template or visual changes use canonical WinUI-style theme keys and `DynamicResource` where theme-bound (no inline hex colors).
- [x] Visual or behavioral choices are grounded in a Section 4 reference authority (in-tree precedent, WinUI 3 CommonStyles, or .NET 10 WPF Themes).
- [ ] `CHANGELOG.md` is updated under `Unreleased`.
- [x] Public docs are updated when consumer behavior changes.
- [x] No unrelated files or local tool state are included.
