### PR TITLE
CI: net8 binaries and automatic GitHub releases on version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 jobs:
@@ -66,6 +67,18 @@ jobs:
             Fluence.Wpf/bin/Release/net10.0-windows10.0.26100.0/WinRT.Runtime.dll
           retention-days: 30
 
+      - name: Upload library artifacts (.NET 8)
+        uses: actions/upload-artifact@v7
+        with:
+          name: fluence-wpf-release-dotnet8
+          path: |
+            Fluence.Wpf/bin/Release/net8.0-windows10.0.26100.0/Fluence.Wpf.dll
+            Fluence.Wpf/bin/Release/net8.0-windows10.0.26100.0/Fluence.Wpf.pdb
+            Fluence.Wpf/bin/Release/net8.0-windows10.0.26100.0/Fluence.Wpf.xml
+            Fluence.Wpf/bin/Release/net8.0-windows10.0.26100.0/Microsoft.Windows.SDK.NET.dll
+            Fluence.Wpf/bin/Release/net8.0-windows10.0.26100.0/WinRT.Runtime.dll
+          retention-days: 30
+
       - name: Upload library artifacts (.NET Framework 4.7.2)
         uses: actions/upload-artifact@v7
         with:
@@ -98,3 +111,39 @@ jobs:
       # - name: Publish to NuGet (tagged releases only)
       #   if: startsWith(github.ref, 'refs/tags/v')
       #   run: dotnet nuget push nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  # Version tags (v*) run the full build/test/pack gates above and then publish a
+  # GitHub release with the per-TFM library binaries, the demo, and the NuGet
+  # package attached. Tags containing '-pre' are marked as prereleases. Write
+  # permission is scoped to this job only; the build job stays read-only.
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+
+      - name: Stage release assets
+        run: |
+          New-Item -ItemType Directory dist | Out-Null
+          Compress-Archive -Path artifacts/fluence-wpf-release-dotnet472/* -DestinationPath "dist/Fluence.Wpf-${{ github.ref_name }}-net472.zip"
+          Compress-Archive -Path artifacts/fluence-wpf-release-dotnet8/* -DestinationPath "dist/Fluence.Wpf-${{ github.ref_name }}-net8.0-windows.zip"
+          Compress-Archive -Path artifacts/fluence-wpf-release-dotnet10/* -DestinationPath "dist/Fluence.Wpf-${{ github.ref_name }}-net10.0-windows.zip"
+          Compress-Archive -Path artifacts/fluence-wpf-demo/* -DestinationPath "dist/Fluence.Wpf.Demo-${{ github.ref_name }}-net472.zip"
+          Copy-Item artifacts/fluence-wpf-nupkg/*.nupkg dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ghArgs = @('release', 'create', '${{ github.ref_name }}')
+          $ghArgs += (Get-ChildItem dist/* | ForEach-Object FullName)
+          $ghArgs += @('--title', 'Fluence.Wpf ${{ github.ref_name }}', '--generate-notes')
+          if ('${{ github.ref_name }}'.Contains('-pre')) { $ghArgs += '--prerelease' }
+          gh @ghArgs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ dotnet test    Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Debug -f net10.0-wi
 
 ### CI/CD pipeline
 
-CI is a single `build` job on `windows-latest` defined in [.github/workflows/build.yml](.github/workflows/build.yml), triggered by any push or pull request targeting `main`. It checks text policy (UTF-8 BOM, LF, banned APIs), restores, builds Release, runs both TFM test lanes (excluding the `Screenshots` category) with TRX output, then packs and uploads artifacts. NuGet publish remains commented out as a deliberate manual release step.
+CI is defined in [.github/workflows/build.yml](.github/workflows/build.yml) and triggered by any push or pull request targeting `main`, plus `v*` tag pushes. The `build` job on `windows-latest` checks text policy (UTF-8 BOM, LF, banned APIs), restores, builds Release, runs both TFM test lanes (excluding the `Screenshots` category) with TRX output, then packs and uploads artifacts (net472, net8.0-windows, and net10.0-windows library binaries, the demo, and the nupkg). A `v*` tag additionally runs a `release` job after `build` succeeds: it zips the per-TFM binaries and the demo, and creates the GitHub release for the tag with those assets and the nupkg attached (tags containing `-pre` are marked prerelease). NuGet publish remains commented out as a deliberate manual release step.
 
 ```mermaid
 flowchart TD
@@ -308,8 +308,9 @@ flowchart TD
     I --> J[Test net10.0-windows10.0.26100.0<br/>filter TestCategory!=Screenshots, TRX]
     J --> K[Upload test results<br/>always]
     K --> L[Pack NuGet]
-    L --> M[Upload artifacts<br/>dotnet10 lib, dotnet472 lib, demo, nupkg]
+    L --> M[Upload artifacts<br/>dotnet10 lib, dotnet8 lib, dotnet472 lib, demo, nupkg]
     M --> N[NuGet publish<br/>commented out / manual]
+    M --> R[Release job, v* tags only<br/>zip per-TFM binaries + demo,<br/>gh release create with assets]
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- CI: pushing a `v*` tag now creates the GitHub release automatically, attaching the `net472`, `net8.0-windows`, and `net10.0-windows` library binaries, the demo app, and the NuGet package (tags containing `-pre` are marked prerelease). The .NET 8 binaries are also uploaded as workflow artifacts on every build.
 - Controls respect the Windows "Show animations in Windows" accessibility setting, read via `SystemParameters.ClientAreaAnimation`. With the setting off, code-driven animations are skipped and controls jump to their final state. Covered: `ProgressRing` and `ProgressBar` indeterminate motion, `FontIcon` spin, `ContentDialog` open and close, `NavigationView` pane and indicator motion, the `Flyout`, `TeachingTip`, and `ComboBox` reveals, the `Expander` slide, `ToggleSwitch` knob and thumb motion, `ListView` insert/remove, and `SmoothScrollViewer` wheel scrolling. Hover/press micro-feedback and other XAML template storyboards are not gated; toggling the OS setting mid-session applies at each animation's next start.
 
 ### Changed


### PR DESCRIPTION
## Summary

- The `build` job now uploads the `net8.0-windows10.0.26100.0` library binaries as a workflow artifact, alongside the existing net472 and net10 uploads (the solution already builds all three TFMs).
- `v*` tag pushes now trigger the workflow and, after the full build/test/pack gates succeed, a new `release` job zips the per-TFM library binaries and the demo, and creates the GitHub release for the tag with those assets and the nupkg attached. Tags containing `-pre` are marked prerelease. `contents: write` is scoped to the release job only.
- AGENTS.md CI description/diagram and the CHANGELOG updated to match.

## Test plan

- PR CI validates the workflow parses and the build job (including the new net8 upload step) runs green.
- The release job is tag-gated; it will be exercised by re-cutting `v0.8.10-pre` after this merges, and the release assets verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTyyEGzqrDLvCK5gBwnBje