### PR TITLE
CI: fix gh release create in the checkout-less release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $ghArgs = @('release', 'create', '${{ github.ref_name }}')
+          # --repo makes gh operate without a local checkout (this job never checks
+          # out the tree; it only downloads the build artifacts).
+          $ghArgs = @('release', 'create', '${{ github.ref_name }}', '--repo', '${{ github.repository }}')
           $ghArgs += (Get-ChildItem dist/* | ForEach-Object FullName)
           $ghArgs += @('--title', 'Fluence.Wpf ${{ github.ref_name }}', '--generate-notes')
           if ('${{ github.ref_name }}'.Contains('-pre')) { $ghArgs += '--prerelease' }


### PR DESCRIPTION
## Summary

The first tag-triggered release run failed at "Create GitHub release" with `fatal: not a git repository`: the release job downloads artifacts but never checks out the tree, and `gh release create` infers the target repo from a local git directory. Passing `--repo ${{ github.repository }}` explicitly lets gh operate without a checkout.

## Test plan

- PR CI validates the workflow parses; the fix is exercised by re-cutting `v0.8.10-pre` after merge and verifying the release is created with all assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTyyEGzqrDLvCK5gBwnBje