### PR TITLE
Adds Fluent-styled Image control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- `Fluence.Wpf.Controls.Image` - a Fluent image presenter framing a picture with a theme-aware 1px `CardStrokeColorDefaultBrush` stroke and a rounded-corner clip driven by `CornerRadius` (default `ControlCornerRadius`), while a real inner WPF image element keeps natural sizing, `Stretch` semantics, and DPI handling. Ships with an `ImageAutomationPeer` (UIA role Image; silent unless `AutomationProperties.Name` is set) and a gallery Data page sample.
+- `Fluence.Wpf.Controls.Image` - a Fluent image presenter framing a picture with a theme-aware 1px `CardStrokeColorDefaultBrush` stroke and a rounded-corner clip driven by `CornerRadius` (default `ControlCornerRadius`), while a real inner WPF image element keeps natural sizing, `Stretch` semantics, and DPI handling. Ships with an `ImageAutomationPeer` (UIA role Image) and a gallery Data page sample. A decorative image stays out of the UI Automation tree entirely: the peer reports itself in neither the control nor the content view until the consumer gives it an accessible name via `AutomationProperties.Name` or `AutomationProperties.LabeledBy`, matching WinUI's `AccessibilityView="Raw"` default for `Image` and the existing `FontIcon` treatment.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Fluence.Wpf.Controls.Image` - a Fluent image presenter framing a picture with a theme-aware 1px `CardStrokeColorDefaultBrush` stroke and a rounded-corner clip driven by `CornerRadius` (default `ControlCornerRadius`), while a real inner WPF image element keeps natural sizing, `Stretch` semantics, and DPI handling. Ships with an `ImageAutomationPeer` (UIA role Image; silent unless `AutomationProperties.Name` is set) and a gallery Data page sample.
+
+### Changed
+
+- `ColorPicker`, the demo shell, and the demo tests now fully qualify their `System.Windows.Controls.Image` references. `Fluence.Wpf.Controls.Image` newly occupies that simple name, so an unqualified `Image` inside the `Fluence.Wpf.Controls` namespace resolved to the Fluence control, and files importing that namespace saw an ambiguous reference. Behavior is unchanged; `ColorPicker.cs` already carried a comment anticipating this.
+
 ### Fixed
 
 - `ProgressBar`: an indeterminate bar now keeps animating when the Windows "Show animations in Windows" accessibility setting is off. It was gated with every other code-driven animation in 0.8.10-Preview, which parked both indeterminate bars at translate 0 and left a motionless block pinned to the left of the track. That reads as a stalled determinate bar, so a healthy operation looked hung. Indeterminate progress carries no value, so its movement is the only status signal it has, and it is therefore treated as essential feedback rather than decoration. A determinate bar still honours the setting, because its fill width conveys the information when frozen. `ProgressRing` is unaffected: it already renders a meaningful static resting arc with the setting off, which a bar has no equivalent of. Regression seen downstream in PSAppDeployToolkit, where `Show-ADTInstallationProgress` returned normally but its dialog sat motionless on any machine with animation effects off - notably affecting screen-reader users, who commonly disable animation effects.

--- a/Fluence.Wpf.Demo/MainWindow.xaml.cs
+++ b/Fluence.Wpf.Demo/MainWindow.xaml.cs
@@ -70,7 +70,7 @@ namespace Fluence.Wpf.Demo
         private bool _isNavigatingBack;
         private bool _isUpdatingExtendedTitleOverlap;
         private NavigationViewItem? _currentNavigationItem;
-        private Image? _titleBarIconView;
+        private System.Windows.Controls.Image? _titleBarIconView;
         private DependencyPropertyDescriptor? _extendsDpd;
         private DependencyPropertyDescriptor? _paneModeDpd;
         private DependencyPropertyDescriptor? _paneOpenDpd;
@@ -632,11 +632,11 @@ namespace Fluence.Wpf.Demo
             ScheduleExtendedTitleOverlapCheck();
         }
 
-        private Image GetTitleBarIconView()
+        private System.Windows.Controls.Image GetTitleBarIconView()
         {
             if (_titleBarIconView is null)
             {
-                _titleBarIconView = new Image
+                _titleBarIconView = new System.Windows.Controls.Image
                 {
                     Width = 20,
                     Height = 20,

--- a/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml
+++ b/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml
@@ -263,6 +263,32 @@
                 </UniformGrid>
             </ContentControl>
             <local:DemoSampleControl SampleDescription="Use Card variants to group related data with different levels of visual emphasis." />
+            <ContentControl x:Name="DemoSampleSlot06DemoContentHost" Visibility="Collapsed">
+                <WrapPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <ui:Image
+                        Width="96"
+                        Height="96"
+                        Margin="{DynamicResource DemoControlGroupItemMargin}"
+                        CornerRadius="0"
+                        Source="pack://application:,,,/Fluence.Wpf.Demo;component/Resources/ControlImages/PersonPictureAnaBowman.png"
+                        Stretch="UniformToFill" />
+                    <ui:Image
+                        Width="96"
+                        Height="96"
+                        Margin="{DynamicResource DemoControlGroupItemMargin}"
+                        CornerRadius="8"
+                        Source="pack://application:,,,/Fluence.Wpf.Demo;component/Resources/ControlImages/PersonPictureShawnHughes.png"
+                        Stretch="UniformToFill" />
+                    <ui:Image
+                        Width="96"
+                        Height="96"
+                        Margin="{DynamicResource DemoControlGroupItemMargin}"
+                        CornerRadius="48"
+                        Source="pack://application:,,,/Fluence.Wpf.Demo;component/Resources/ControlImages/PersonPicturePriyaKapoor.png"
+                        Stretch="UniformToFill" />
+                </WrapPanel>
+            </ContentControl>
+            <local:DemoSampleControl SampleDescription="Use Image to present pictures with a theme-aware stroke; CornerRadius drives the rounded clip from square to circular." />
         </StackPanel>
     </ui:SmoothScrollViewer>
 </UserControl>

--- a/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml.cs
+++ b/Fluence.Wpf.Demo/Pages/GalleryDataPage.xaml.cs
@@ -331,6 +331,49 @@ namespace Fluence.Wpf.Demo.Pages
                                                         "        }\n" +
                                                         "    }\n" +
                                                         "}\n";
+        private const string ImageXamlSource = "<UserControl\n" +
+                                               "    x:Class=\"Fluence.Wpf.Demo.Pages.Data.ImageSample\"\n" +
+                                               "    xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\"\n" +
+                                               "    xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n" +
+                                               "    xmlns:ui=\"clr-namespace:Fluence.Wpf.Controls;assembly=Fluence.Wpf\">\n" +
+                                               "    <WrapPanel\n" +
+                                               "        HorizontalAlignment=\"Center\"\n" +
+                                               "        VerticalAlignment=\"Center\">\n" +
+                                               "        <ui:Image\n" +
+                                               "            Width=\"96\"\n" +
+                                               "            Height=\"96\"\n" +
+                                               "            Margin=\"0,0,12,12\"\n" +
+                                               "            CornerRadius=\"0\"\n" +
+                                               "            Source=\"pack://application:,,,/Fluence.Wpf.Demo;component/Resources/ControlImages/PersonPictureAnaBowman.png\"\n" +
+                                               "            Stretch=\"UniformToFill\" />\n" +
+                                               "        <ui:Image\n" +
+                                               "            Width=\"96\"\n" +
+                                               "            Height=\"96\"\n" +
+                                               "            Margin=\"0,0,12,12\"\n" +
+                                               "            CornerRadius=\"8\"\n" +
+                                               "            Source=\"pack://application:,,,/Fluence.Wpf.Demo;component/Resources/ControlImages/PersonPictureShawnHughes.png\"\n" +
+                                               "            Stretch=\"UniformToFill\" />\n" +
+                                               "        <ui:Image\n" +
+                                               "            Width=\"96\"\n" +
+                                               "            Height=\"96\"\n" +
+                                               "            Margin=\"0,0,12,12\"\n" +
+                                               "            CornerRadius=\"48\"\n" +
+                                               "            Source=\"pack://application:,,,/Fluence.Wpf.Demo;component/Resources/ControlImages/PersonPicturePriyaKapoor.png\"\n" +
+                                               "            Stretch=\"UniformToFill\" />\n" +
+                                               "    </WrapPanel>\n" +
+                                               "</UserControl>\n";
+        private const string ImageCSharpSource = "using System.Windows.Controls;\n" +
+                                                 "\n" +
+                                                 "namespace Fluence.Wpf.Demo.Pages.Data\n" +
+                                                 "{\n" +
+                                                 "    public partial class ImageSample : UserControl\n" +
+                                                 "    {\n" +
+                                                 "        public ImageSample()\n" +
+                                                 "        {\n" +
+                                                 "            InitializeComponent();\n" +
+                                                 "        }\n" +
+                                                 "    }\n" +
+                                                 "}\n";
         private const string PersonPictureXamlSource = "<UserControl\n" +
                                                        "    x:Class=\"Fluence.Wpf.Demo.Pages.Data.PersonPictureSample\"\n" +
                                                        "    xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\"\n" +
@@ -407,7 +450,8 @@ namespace Fluence.Wpf.Demo.Pages
                 new DemoSampleSource(2, ListViewEmptyStateXamlSource, ListViewEmptyStateCSharpSource),
                 new DemoSampleSource(3, ListBoxSelectionXamlSource, ListBoxSelectionCSharpSource),
                 new DemoSampleSource(4, PersonPictureXamlSource, PersonPictureCSharpSource),
-                new DemoSampleSource(5, CardVariantsXamlSource, CardVariantsCSharpSource));
+                new DemoSampleSource(5, CardVariantsXamlSource, CardVariantsCSharpSource),
+                new DemoSampleSource(6, ImageXamlSource, ImageCSharpSource));
         }
 
         private void AddListItem_Click(object sender, RoutedEventArgs e)

--- a/Fluence.Wpf.Tests/ControlTests.Image.cs
+++ b/Fluence.Wpf.Tests/ControlTests.Image.cs
@@ -1,0 +1,189 @@
+﻿/*
+ * Copyright 2026 Dan Cunningham
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace Fluence.Wpf.Tests
+{
+    /// <summary>
+    /// Phase 2 tests: Fluent <see cref="Controls.Image"/>.
+    /// Authority: in-tree precedent (PersonPicture stroke tokens, FontIcon non-interactive shape);
+    /// WinUI 3 ships no styled Image control.
+    /// </summary>
+    public partial class ControlTests
+    {
+        // ---------------------------------------------------------------------------
+        // Phase 2  Image
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Builds a small frozen probe bitmap without any file IO.
+        /// </summary>
+        private static BitmapSource CreateProbeBitmap()
+        {
+            DrawingVisual visual = new();
+            using (DrawingContext context = visual.RenderOpen())
+            {
+                context.DrawRectangle(Brushes.OrangeRed, pen: null, new Rect(0, 0, 16, 16));
+            }
+            RenderTargetBitmap bitmap = new(16, 16, 96, 96, PixelFormats.Pbgra32);
+            bitmap.Render(visual);
+            bitmap.Freeze();
+            return bitmap;
+        }
+
+        [TestMethod]
+        public void Image_DefaultStyle_TemplatePartsPresent()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                Controls.Image image = new();
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                DrainDispatcher(w.Dispatcher);
+
+                System.Windows.Controls.Image? inner = FindVisualChildByName<System.Windows.Controls.Image>(image, "PART_Image");
+                Assert.IsNotNull(inner, "PART_Image must be present.");
+
+                System.Windows.Controls.Border? frame = FindVisualChildByName<System.Windows.Controls.Border>(image, "PART_ImageBorder");
+                Assert.IsNotNull(frame, "PART_ImageBorder must be present.");
+                w.Close();
+            });
+        }
+
+        [TestMethod]
+        public void Image_SourceAndStretch_FlowToInnerImage()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                BitmapSource probe = CreateProbeBitmap();
+                Controls.Image image = new() { Source = probe, Stretch = Stretch.UniformToFill };
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                DrainDispatcher(w.Dispatcher);
+
+                System.Windows.Controls.Image? inner = FindVisualChildByName<System.Windows.Controls.Image>(image, "PART_Image");
+                Assert.IsNotNull(inner);
+                Assert.AreSame(probe, inner.Source,
+                    "Source must flow to PART_Image via TemplateBinding.");
+                Assert.AreEqual(Stretch.UniformToFill, inner.Stretch,
+                    "Stretch must flow to PART_Image via TemplateBinding.");
+                w.Close();
+            });
+        }
+
+        [TestMethod]
+        public void Image_CornerRadius_SetsAndClearsInnerClip()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                Controls.Image image = new() { Source = CreateProbeBitmap(), CornerRadius = new CornerRadius(8) };
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                DrainDispatcher(w.Dispatcher);
+                w.UpdateLayout();
+                DrainDispatcher(w.Dispatcher);
+
+                System.Windows.Controls.Image? inner = FindVisualChildByName<System.Windows.Controls.Image>(image, "PART_Image");
+                Assert.IsNotNull(inner);
+
+                RectangleGeometry? clip = inner.Clip as RectangleGeometry;
+                Assert.IsNotNull(clip, "CornerRadius > 0 must set a RectangleGeometry clip on PART_Image.");
+                Assert.AreEqual(8.0, clip.RadiusX, "The clip must use the top-left corner radius uniformly.");
+                Assert.IsTrue(clip.IsFrozen, "The clip geometry must be frozen.");
+
+                image.CornerRadius = new CornerRadius(0);
+                DrainDispatcher(w.Dispatcher);
+                Assert.IsNull(inner.Clip, "CornerRadius = 0 must clear the clip on PART_Image.");
+                w.Close();
+            });
+        }
+
+        [TestMethod]
+        public void Image_ThemeCycle_StyleRemainsApplied()
+        {
+            WpfTestSta.Invoke(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                Controls.Image image = new() { Source = CreateProbeBitmap() };
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                DrainDispatcher(w.Dispatcher);
+
+                ThemeTestHelpers.ApplyStandardThemeCycle();
+                DrainDispatcher(w.Dispatcher);
+
+                System.Windows.Controls.Border? frame = FindVisualChildByName<System.Windows.Controls.Border>(image, "PART_ImageBorder");
+                Assert.IsNotNull(frame, "PART_ImageBorder must still be present after theme cycle.");
+                Assert.IsNotNull(frame.BorderBrush, "The stroke brush must re-resolve after theme cycle.");
+                w.Close();
+            });
+        }
+
+        [TestMethod]
+        public void Image_AutomationPeer_IsImageAutomationPeer()
+        {
+            RunOnStaThread(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                Controls.Image image = new();
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                _ = image.ApplyTemplate();
+                DrainDispatcher(w.Dispatcher);
+
+                AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(image);
+                _ = Assert.IsInstanceOfType<Automation.ImageAutomationPeer>(peer,
+                    "Image must create a Fluence ImageAutomationPeer.");
+                Assert.AreEqual(AutomationControlType.Image, peer.GetAutomationControlType(),
+                    "Image automation peer must report control type Image.");
+                Assert.AreEqual("Image", peer.GetClassName(), StringComparer.Ordinal,
+                    "Image automation peer must report class name 'Image'.");
+                w.Close();
+            });
+        }
+    }
+}

--- a/Fluence.Wpf.Tests/ControlTests.Image.cs
+++ b/Fluence.Wpf.Tests/ControlTests.Image.cs
@@ -29,6 +29,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -182,6 +183,97 @@ namespace Fluence.Wpf.Tests
                     "Image automation peer must report control type Image.");
                 Assert.AreEqual("Image", peer.GetClassName(), StringComparer.Ordinal,
                     "Image automation peer must report class name 'Image'.");
+                w.Close();
+            });
+        }
+
+        /// <summary>
+        /// An image with no accessible name is decorative and must leave the UI Automation tree
+        /// entirely, matching WinUI's AccessibilityView=Raw default and FontIcon's treatment. If it
+        /// stayed in the content view a screen reader would announce an empty image element.
+        /// </summary>
+        [TestMethod]
+        public void Image_AutomationPeer_UnnamedImageIsExcludedFromBothViews()
+        {
+            RunOnStaThread(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                Controls.Image image = new();
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                _ = image.ApplyTemplate();
+                DrainDispatcher(w.Dispatcher);
+
+                AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(image);
+                Assert.IsFalse(peer.IsControlElement(),
+                    "An unnamed Image is decorative and must be excluded from the UI Automation control view.");
+                Assert.IsFalse(peer.IsContentElement(),
+                    "An unnamed Image must be excluded from the UI Automation content view so nothing announces an empty image.");
+                w.Close();
+            });
+        }
+
+        /// <summary>
+        /// Setting <c>AutomationProperties.Name</c> makes the image meaningful, so it must appear in
+        /// both automation views and report that name.
+        /// </summary>
+        [TestMethod]
+        public void Image_AutomationPeer_NamedImageIsIncludedInBothViews()
+        {
+            RunOnStaThread(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                Controls.Image image = new();
+                AutomationProperties.SetName(image, "Company logo");
+                Window w = new() { Content = image, Width = 200, Height = 200 };
+                w.Show();
+                _ = image.ApplyTemplate();
+                DrainDispatcher(w.Dispatcher);
+
+                AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(image);
+                Assert.IsTrue(peer.IsControlElement(),
+                    "A named Image conveys meaning and must appear in the UI Automation control view.");
+                Assert.IsTrue(peer.IsContentElement(),
+                    "A named Image must appear in the UI Automation content view so a screen reader reads it.");
+                Assert.AreEqual("Company logo", peer.GetName(), StringComparer.Ordinal,
+                    "The peer must surface the accessible name the consumer set.");
+                w.Close();
+            });
+        }
+
+        /// <summary>
+        /// Labelling by another element is a legitimate way to name an image, and the base peer
+        /// already resolves its name through it, so a LabeledBy image must not be dropped from the
+        /// tree. This is why the peer checks LabeledBy as well as Name.
+        /// </summary>
+        [TestMethod]
+        public void Image_AutomationPeer_LabeledByImageIsIncludedInBothViews()
+        {
+            RunOnStaThread(static () =>
+            {
+                Application? app = EnsureApplication();
+                _ = MergeGenericDictionary(app);
+
+                System.Windows.Controls.TextBlock label = new() { Text = "Product photo" };
+                Controls.Image image = new();
+                AutomationProperties.SetLabeledBy(image, label);
+                System.Windows.Controls.StackPanel host = new();
+                _ = host.Children.Add(label);
+                _ = host.Children.Add(image);
+                Window w = new() { Content = host, Width = 200, Height = 200 };
+                w.Show();
+                _ = image.ApplyTemplate();
+                DrainDispatcher(w.Dispatcher);
+
+                AutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(image);
+                Assert.IsTrue(peer.IsControlElement(),
+                    "An Image named through AutomationProperties.LabeledBy must appear in the control view.");
+                Assert.IsTrue(peer.IsContentElement(),
+                    "An Image named through AutomationProperties.LabeledBy must appear in the content view.");
                 w.Close();
             });
         }

--- a/Fluence.Wpf.Tests/DemoMainWindowTests.cs
+++ b/Fluence.Wpf.Tests/DemoMainWindowTests.cs
@@ -152,7 +152,7 @@ namespace Fluence.Wpf.Tests
                 Window window = CreateHostWindow(page);
                 try
                 {
-                    Image? image = FindByName<Image>(page, "BrandHeroImage");
+                    System.Windows.Controls.Image? image = FindByName<System.Windows.Controls.Image>(page, "BrandHeroImage");
                     Assert.IsNotNull(image, "Home page should expose the brand hero image.");
 
                     DrawingImage? light = Application.Current.TryFindResource("FluenceHeaderLightDrawingImage") as DrawingImage;
@@ -582,7 +582,7 @@ namespace Fluence.Wpf.Tests
                     Assert.IsNotNull(titleIcon, "Extended title bar icon presenter should exist.");
                     Assert.AreEqual(Visibility.Visible, titleIcon.Visibility,
                         "Extended title bar icon should be visible by default.");
-                    Image? titleIconImage = FindVisualChild<Image>(titleIcon);
+                    System.Windows.Controls.Image? titleIconImage = FindVisualChild<System.Windows.Controls.Image>(titleIcon);
                     Assert.IsNotNull(titleIconImage, "Extended title bar icon should render an Image.");
                     Assert.AreEqual(20.0, titleIconImage.ActualWidth, 0.5,
                         "Extended title bar icon should match the larger navigation glyph size.");

--- a/Fluence.Wpf/Automation/ImageAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/ImageAutomationPeer.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Copyright 2026 Dan Cunningham
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System.Windows.Automation.Peers;
+
+namespace Fluence.Wpf.Automation
+{
+    /// <summary>
+    /// Exposes <see cref="Controls.Image"/> to UI Automation as an image element.
+    /// The peer reports no name of its own, so a decorative image stays silent to
+    /// assistive technology unless the consumer sets an explicit
+    /// <see cref="System.Windows.Automation.AutomationProperties.NameProperty"/> value.
+    /// </summary>
+    /// <remarks>Initializes a new instance of the <see cref="ImageAutomationPeer"/> class.</remarks>
+    /// <param name="owner">The <see cref="Controls.Image"/> control represented by this automation peer.</param>
+    public class ImageAutomationPeer(Controls.Image owner) : FrameworkElementAutomationPeer(owner)
+    {
+        /// <inheritdoc />
+        protected override string GetClassNameCore()
+        {
+            return nameof(Controls.Image);
+        }
+
+        /// <inheritdoc />
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Image;
+        }
+    }
+}

--- a/Fluence.Wpf/Automation/ImageAutomationPeer.cs
+++ b/Fluence.Wpf/Automation/ImageAutomationPeer.cs
@@ -26,15 +26,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 
 namespace Fluence.Wpf.Automation
 {
     /// <summary>
-    /// Exposes <see cref="Controls.Image"/> to UI Automation as an image element.
-    /// The peer reports no name of its own, so a decorative image stays silent to
-    /// assistive technology unless the consumer sets an explicit
-    /// <see cref="System.Windows.Automation.AutomationProperties.NameProperty"/> value.
+    /// Exposes <see cref="Controls.Image"/> to UI Automation as an image element, but only once the
+    /// consumer has given it an accessible name. An unnamed image is treated as decorative and is
+    /// dropped from both the control and content views, so assistive technology never announces a
+    /// bare unlabelled image element.
+    /// Authority: WinUI keeps <c>Image</c> at <c>AccessibilityView="Raw"</c> until it is named, and
+    /// Microsoft's UI Automation guidance is that decorative graphics stay out of the tree entirely.
+    /// In-tree precedent: <see cref="FontIconAutomationPeer"/> for the both-views exclusion, and
+    /// <see cref="TextBlockAutomationPeer"/> for keying that exclusion off the accessible name.
     /// </summary>
     /// <remarks>Initializes a new instance of the <see cref="ImageAutomationPeer"/> class.</remarks>
     /// <param name="owner">The <see cref="Controls.Image"/> control represented by this automation peer.</param>
@@ -50,6 +55,43 @@ namespace Fluence.Wpf.Automation
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
             return AutomationControlType.Image;
+        }
+
+        /// <inheritdoc />
+        protected override bool IsControlElementCore()
+        {
+            return HasAccessibleName();
+        }
+
+        /// <inheritdoc />
+        protected override bool IsContentElementCore()
+        {
+            return HasAccessibleName();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the consumer has given this image an accessible name,
+        /// either directly through <see cref="AutomationProperties.NameProperty"/> or indirectly
+        /// through <see cref="AutomationProperties.LabeledByProperty"/>.
+        /// <para>
+        /// Both views are gated on this. An image differs from a <see cref="TextBlockAutomationPeer"/>,
+        /// which leaves the content view alone: a text element still carries its own readable text
+        /// when unnamed, whereas an unnamed image carries nothing, so leaving it in the content view
+        /// would make a screen reader announce an empty image. That is the noise this control exists
+        /// to avoid.
+        /// </para>
+        /// <para>
+        /// <see cref="AutomationProperties.LabeledByProperty"/> is honoured as well as
+        /// <see cref="AutomationProperties.NameProperty"/> because labelling by another element is a
+        /// legitimate way to name an image, and the base peer already resolves its name through it.
+        /// Checking only the name would silently drop a properly labelled image out of the tree.
+        /// </para>
+        /// </summary>
+        /// <returns><see langword="true"/> when the image has an accessible name; otherwise <see langword="false"/>.</returns>
+        private bool HasAccessibleName()
+        {
+            return !string.IsNullOrWhiteSpace(AutomationProperties.GetName(Owner))
+                || AutomationProperties.GetLabeledBy(Owner) is not null;
         }
     }
 }

--- a/Fluence.Wpf/Controls/ColorPicker.cs
+++ b/Fluence.Wpf/Controls/ColorPicker.cs
@@ -65,7 +65,7 @@ namespace Fluence.Wpf.Controls
     /// text inputs commit live on every valid keystroke like WinUI; the hex input commits
     /// on Enter or focus loss, a deliberate deviation from WinUI's live hex commit.
     /// </remarks>
-    [TemplatePart(Name = PART_SpectrumImage, Type = typeof(Image))]
+    [TemplatePart(Name = PART_SpectrumImage, Type = typeof(System.Windows.Controls.Image))]
     [TemplatePart(Name = PART_SpectrumArea, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = PART_SpectrumThumb, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = PART_HueSlider, Type = typeof(RangeBase))]
@@ -129,7 +129,7 @@ namespace Fluence.Wpf.Controls
         private static readonly Brush CheckerboardBrush = CreateCheckerboardBrush();
         private static readonly Brush HueRainbowBrush = CreateHueRainbowBrush();
 
-        private Image? _spectrumImage;
+        private System.Windows.Controls.Image? _spectrumImage;
         private FrameworkElement? _spectrumArea;
         private FrameworkElement? _spectrumThumb;
         private RangeBase? _hueSlider;
@@ -527,7 +527,7 @@ namespace Fluence.Wpf.Controls
 
             base.OnApplyTemplate();
 
-            _spectrumImage = GetTemplateChild(PART_SpectrumImage) as Image;
+            _spectrumImage = GetTemplateChild(PART_SpectrumImage) as System.Windows.Controls.Image;
             _spectrumArea = GetTemplateChild(PART_SpectrumArea) as FrameworkElement;
             _spectrumThumb = GetTemplateChild(PART_SpectrumThumb) as FrameworkElement;
             _hueSlider = GetTemplateChild(PART_HueSlider) as RangeBase;
@@ -731,7 +731,7 @@ namespace Fluence.Wpf.Controls
 
             _spectrumBitmap.WritePixels(new Int32Rect(0, 0, SpectrumSize, SpectrumSize), pixels, SpectrumSize * 4, 0);
             _spectrumBitmapHue = _hue;
-            _spectrumImage.SetCurrentValue(Image.SourceProperty, _spectrumBitmap);
+            _spectrumImage.SetCurrentValue(System.Windows.Controls.Image.SourceProperty, _spectrumBitmap);
         }
 
         /// <summary>

--- a/Fluence.Wpf/Controls/Image.cs
+++ b/Fluence.Wpf/Controls/Image.cs
@@ -1,0 +1,190 @@
+﻿/*
+ * Copyright 2026 Dan Cunningham
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+// IMPORTANT: every reference to Image / Border in this file MUST be fully qualified
+// (System.Windows.Controls.Image, System.Windows.Controls.Border). This file declares
+// Fluence.Wpf.Controls.Image and sits inside that namespace, so an unqualified Image
+// resolves to this control and the template part contract would reference itself. The
+// parts are typed against the stock WPF types because the default template hosts stock
+// elements. A using alias would read better but RCS1056 bans alias directives, and the
+// repo has no other alias; see ColorPicker.cs and DatePicker.cs for the same pattern.
+namespace Fluence.Wpf.Controls
+{
+    /// <summary>
+    /// A Fluent Design image presenter that frames a picture with a theme-aware 1px stroke and
+    /// rounded-corner clipping while delegating natural sizing, stretch semantics, and DPI
+    /// handling to a real inner <see cref="System.Windows.Controls.Image"/>.
+    /// Authority: in-tree precedent (PersonPicture stroke tokens, FontIcon non-interactive shape);
+    /// WinUI 3 ships no styled Image control, so the frame follows the Card stroke idiom.
+    /// </summary>
+    [TemplatePart(Name = PART_Image, Type = typeof(System.Windows.Controls.Image))]
+    [TemplatePart(Name = PART_ImageBorder, Type = typeof(System.Windows.Controls.Border))]
+    public class Image : Control
+    {
+        // Template part names.
+        private const string PART_Image = "PART_Image";
+        private const string PART_ImageBorder = "PART_ImageBorder";
+
+        /// <summary>
+        /// Initializes static members of the Image class and overrides the default style key to
+        /// associate the control with its style.
+        /// </summary>
+        /// <remarks>This static constructor ensures that the Image control uses the correct
+        /// default style as defined in the application's resources. This is necessary for custom
+        /// controls to apply their styles properly in WPF.</remarks>
+        static Image()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(
+                typeof(Image),
+                new FrameworkPropertyMetadata(typeof(Image)));
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="Source"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty SourceProperty =
+            DependencyProperty.Register(
+                nameof(Source),
+                typeof(ImageSource),
+                typeof(Image),
+                new FrameworkPropertyMetadata(defaultValue: null));
+
+        /// <summary>
+        /// Gets or sets the image source to display. When <see langword="null"/> (default)
+        /// nothing is drawn inside the frame.
+        /// </summary>
+        public ImageSource? Source
+        {
+            get => (ImageSource?)GetValue(SourceProperty);
+            set => SetValue(SourceProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="Stretch"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty StretchProperty =
+            DependencyProperty.Register(
+                nameof(Stretch),
+                typeof(Stretch),
+                typeof(Image),
+                new FrameworkPropertyMetadata(Stretch.Uniform));
+
+        /// <summary>
+        /// Gets or sets how the image fills the available space. The default is
+        /// <see cref="Stretch.Uniform"/>, preserving the source aspect ratio.
+        /// </summary>
+        public Stretch Stretch
+        {
+            get => (Stretch)GetValue(StretchProperty);
+            set => SetValue(StretchProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="CornerRadius"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CornerRadiusProperty =
+            DependencyProperty.Register(
+                nameof(CornerRadius),
+                typeof(CornerRadius),
+                typeof(Image),
+                new FrameworkPropertyMetadata(new CornerRadius(4), OnCornerRadiusChanged));
+
+        /// <summary>
+        /// Gets or sets the corner radius of the frame. The stroke border template-binds this
+        /// value directly; the inner image is clipped in code using the top-left radius uniformly
+        /// (the WPF Border corner-clip idiom). Set to 0 to disable clipping.
+        /// </summary>
+        public CornerRadius CornerRadius
+        {
+            get => (CornerRadius)GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
+        }
+
+        /// <inheritdoc />
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+            _image = GetTemplateChild(PART_Image) as System.Windows.Controls.Image;
+            UpdateImageClip();
+        }
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new Automation.ImageAutomationPeer(this);
+        }
+
+        /// <inheritdoc />
+        protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+        {
+            base.OnRenderSizeChanged(sizeInfo);
+            UpdateImageClip();
+        }
+
+        private static void OnCornerRadiusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((Image)d).UpdateImageClip();
+        }
+
+        /// <summary>
+        /// Applies or clears the rounded-corner clip on the inner image. The template stretches
+        /// the inner image across the whole root grid, so the control's render size is the image
+        /// element's coordinate space; the radius is clamped to half the smaller dimension.
+        /// </summary>
+        private void UpdateImageClip()
+        {
+            if (_image is null)
+            {
+                return;
+            }
+            double radius = CornerRadius.TopLeft;
+            Size size = RenderSize;
+            if (radius <= 0 || size.Width <= 0 || size.Height <= 0)
+            {
+                _image.Clip = null;
+                return;
+            }
+            double clamped = Math.Min(radius, Math.Min(size.Width, size.Height) / 2);
+            RectangleGeometry clip = new(new Rect(size), clamped, clamped);
+            clip.Freeze();
+            _image.Clip = clip;
+        }
+
+        /// <summary>
+        /// The inner WPF image element that renders <see cref="Source"/>, or null before the
+        /// template is applied.
+        /// </summary>
+        private System.Windows.Controls.Image? _image;
+    }
+}

--- a/Fluence.Wpf/Themes/Controls/Image.xaml
+++ b/Fluence.Wpf/Themes/Controls/Image.xaml
@@ -1,0 +1,46 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Fluence.Wpf.Controls"
+    >
+
+    <!--
+        Fluent Image style.
+        Authority: in-tree precedent (PersonPicture stroke tokens, FontIcon non-interactive shape)
+        plus the out-of-process UI PRD; WinUI 3 ships no styled Image control, so the frame follows
+        the Card stroke idiom (CardStrokeColorDefaultBrush 1px, ControlCornerRadius).
+        The rounded-corner clip on PART_Image is managed in code (Image.UpdateImageClip); the
+        PART_ImageBorder overlay draws the stroke above the picture edge.
+    -->
+    <Style TargetType="{x:Type controls:Image}">
+        <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type controls:Image}">
+                    <Grid>
+                        <!-- The real WPF image: natural sizing, Stretch semantics, DPI handling. -->
+                        <Image
+                            x:Name="PART_Image"
+                            Source="{TemplateBinding Source}"
+                            Stretch="{TemplateBinding Stretch}"
+                            />
+
+                        <!-- Stroke overlay drawn above the picture edge; no background fill. -->
+                        <Border
+                            x:Name="PART_ImageBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="UseLayoutRounding" Value="True" />
+    </Style>
+
+</ResourceDictionary>

--- a/Fluence.Wpf/Themes/Generic.xaml
+++ b/Fluence.Wpf/Themes/Generic.xaml
@@ -57,6 +57,7 @@
         <ResourceDictionary Source="/Fluence.Wpf;component/Themes/Controls/BreadcrumbBar.xaml" />
         <ResourceDictionary Source="/Fluence.Wpf;component/Themes/Controls/PipsPager.xaml" />
         <ResourceDictionary Source="/Fluence.Wpf;component/Themes/Controls/ToggleSplitButton.xaml" />
+        <ResourceDictionary Source="/Fluence.Wpf;component/Themes/Controls/Image.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
 </ResourceDictionary>

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -401,7 +401,7 @@ flipping the OS setting mid-session takes effect at each animation's next natura
 | `ProgressRing` | ProgressBar | `AutomationProperties.Name` | RangeValue |
 | `Card` | Button (when clickable) / Group (non-clickable) | `AutomationProperties.Name` (or its content) | Invoke (when clickable) |
 | `PersonPicture` | Image | Display name or initials | none |
-| `Image` | Image | `AutomationProperties.Name` (unset = decorative) | none |
+| `Image` | Image | `AutomationProperties.Name` or `AutomationProperties.LabeledBy` (neither set = decorative, excluded from the control and content views) | none |
 | `ContentDialog` | Window | `Title` | none (focus trapped inside; assertive live region announces `Title` on open) |
 | `TeachingTip` | ToolTip | `Title` and `Subtitle` (live region) | none |
 | `AppBarButton` | Button | `Label` (surfaced as `AutomationProperties.Name`) or an explicit `AutomationProperties.Name` | Invoke |

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -55,6 +55,7 @@ xmlns:uicore="clr-namespace:Fluence.Wpf;assembly=Fluence.Wpf"
 | Trees & collections | `TreeView`, `TreeViewItem`                                                                                                         |
 | Layout / surfaces   | `Card`, `Expander`, `Border`, `StackPanel`, `DockPanel`, `SmoothScrollViewer`, `Separator`                                         |
 | Person / social     | `PersonPicture`                                                                                                                    |
+| Media               | `Image`                                                                                                                            |
 | Icons               | `FontIcon`                                                                                                                         |
 
 Tab strip and scroll bar styling are provided via merged themes (see `Themes/Generic.xaml`).
@@ -164,11 +165,12 @@ Key API:
   <a href="../../api/Fluence.Wpf.Controls.ListBoxItem.html">ListBoxItem</a>
   <a href="../../api/Fluence.Wpf.Controls.ListView.html">ListView</a>
   <a href="../../api/Fluence.Wpf.Controls.PersonPicture.html">PersonPicture</a>
+  <a href="../../api/Fluence.Wpf.Controls.Image.html">Image</a>
   <a href="../../api/Fluence.Wpf.CardVariant.html">CardVariant</a>
   <a href="../../api/Fluence.Wpf.ListViewState.html">ListViewState</a>
 </div>
 
-Collection controls keep WPF item-source and template behavior. `Card` adds header, footer, icon, clickable, and pressed-state APIs.
+Collection controls keep WPF item-source and template behavior. `Card` adds header, footer, icon, clickable, and pressed-state APIs. `Image` frames a picture with a theme-aware 1px stroke and a rounded-corner clip driven by `CornerRadius`, while `Source` and `Stretch` behave like the stock WPF image element.
 
 ### Data Binding
 
@@ -349,6 +351,7 @@ Key API:
   <a href="../../api/Fluence.Wpf.Automation.RatingControlAutomationPeer.html">RatingControlAutomationPeer</a>
   <a href="../../api/Fluence.Wpf.Automation.PasswordBoxAutomationPeer.html">PasswordBoxAutomationPeer</a>
   <a href="../../api/Fluence.Wpf.Automation.PersonPictureAutomationPeer.html">PersonPictureAutomationPeer</a>
+  <a href="../../api/Fluence.Wpf.Automation.ImageAutomationPeer.html">ImageAutomationPeer</a>
   <a href="../../api/Fluence.Wpf.Automation.HyperlinkButtonAutomationPeer.html">HyperlinkButtonAutomationPeer</a>
   <a href="../../api/Fluence.Wpf.Automation.CardAutomationPeer.html">CardAutomationPeer</a>
 </div>
@@ -398,6 +401,7 @@ flipping the OS setting mid-session takes effect at each animation's next natura
 | `ProgressRing` | ProgressBar | `AutomationProperties.Name` | RangeValue |
 | `Card` | Button (when clickable) / Group (non-clickable) | `AutomationProperties.Name` (or its content) | Invoke (when clickable) |
 | `PersonPicture` | Image | Display name or initials | none |
+| `Image` | Image | `AutomationProperties.Name` (unset = decorative) | none |
 | `ContentDialog` | Window | `Title` | none (focus trapped inside; assertive live region announces `Title` on open) |
 | `TeachingTip` | ToolTip | `Title` and `Subtitle` (live region) | none |
 | `AppBarButton` | Button | `Label` (surfaced as `AutomationProperties.Name`) or an explicit `AutomationProperties.Name` | Invoke |


### PR DESCRIPTION
## Summary

- Introduces `Fluence.Wpf.Controls.Image`, a new Fluent-design image presenter that frames a picture with a theme-aware 1px stroke and rounded-corner clipping, while using the native WPF `System.Windows.Controls.Image` for core rendering. This change also includes an `ImageAutomationPeer` and required qualifying existing `System.Windows.Controls.Image` references across the solution to resolve ambiguity.

## Review Focus

- Correctness of `System.Windows.Controls.Image` qualifications throughout the solution.
- Visual fidelity of the new `Image` control, specifically its border and corner radius effects.
- Accessibility implications of the `ImageAutomationPeer`, ensuring decorative images remain silent by default.

## How to Test

1.  Run the `Fluence.Wpf.Demo` application and navigate to the "Gallery Data" page.
2.  Observe the new `Image` samples, verifying correct stroke, corner radius, and image stretching behaviors.
3.  Confirm existing `System.Windows.Controls.Image` usages (e.g., in `MainWindow`'s title bar, `ColorPicker`'s spectrum) still function as expected.
4.  Cycle through Light, Dark, and High Contrast themes to ensure the stroke color updates correctly.
5.  Execute `Fluence.Wpf.Tests` and confirm all tests, especially those in `ControlTests.Image.cs`, pass.

*(Please include before/after screenshots or GIFs for the UI changes in the demo application.)*

## Verification

- [x] `dotnet build Fluence.Wpf.sln -c Release --no-restore -v minimal` (0 errors / 0 warnings, both TFMs)
- [x] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net472 --no-build`
- [x] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net10.0-windows10.0.26100.0 --no-build`
- [ ] `pwsh .claude/hooks/post-tool-util.ps1 -CheckAll` passes (UTF-8 BOM, LF, banned APIs, no hard-coded hex or em/en dashes).
- [ ] Visual pass completed in `Fluence.Wpf.Demo` for Light, Dark, High Contrast, accent swap, and relevant backdrop.

## Checklist

- [x] Public API changes have XML docs and tests; the test count does not drop below the baseline.
- [x] Template or visual changes use canonical WinUI-style theme keys and `DynamicResource` where theme-bound (no inline hex colors).
- [x] Visual or behavioral choices are grounded in a Section 4 reference authority (in-tree precedent, WinUI 3 CommonStyles, or .NET 10 WPF Themes).
- [x] `CHANGELOG.md` is updated under `Unreleased`.
- [x] Public docs are updated when consumer behavior changes.
- [x] No unrelated files or local tool state are included.