### PR TITLE
Fix the stale computed dictionary that shadowed slot [0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- The theme engine no longer leaves a previously published computed dictionary merged into `Application.Resources`. `RemoveFluenceDictionaries` recognised Typography and Generic by their pack URI, but the computed dictionary at slot [0] is built in code and has no `Source`, so seeding the slots again inserted a fresh computed dictionary at [0] and left the previous one further down the list. WPF resolves merged dictionaries last-wins, so the stale one answered lookups the fresh one owned: once a High Contrast dictionary had been published, later Light applies resolved opaque High Contrast tokens, which is what turned the translucent `ComboBox` dropdown surface opaque on a CI runner. Every published computed dictionary now carries a marker key that the removal pass recognises, and `DictionaryStabilityTests` pins the re-seed path.
+
 ## [0.8.14-Preview] - 2026-08-24
 
 ### Added

--- a/Fluence.Wpf.Tests/DictionaryStabilityTests.cs
+++ b/Fluence.Wpf.Tests/DictionaryStabilityTests.cs
@@ -75,6 +75,31 @@ namespace Fluence.Wpf.Tests
         }
 
         [Fact]
+        public Task ReInitialization_DropsThePreviouslyPublishedComputedDictionaryAsync()
+        {
+            // A computed dictionary has no Source, so it cannot be recognised by pack URI the way
+            // Typography and Generic are. Seeding the slots again (which every test isolation reset
+            // forces) used to insert a fresh one at [0] and leave the previous one further down the
+            // list, where WPF's last-wins merge order let it answer lookups the new one owned. On a
+            // machine that had published high contrast at some point, later Light applies then
+            // resolved opaque high contrast tokens.
+            return WpfTestSta.RunOnStaAsync(static () =>
+            {
+                Application app = Application.Current;
+
+                ApplicationThemeManager.Apply(ApplicationTheme.HighContrast, BackdropType.None, updateAccent: false);
+                ApplicationThemeManager.ResetForTesting();
+                ApplicationAccentColorManager.ResetForTesting();
+                ApplicationThemeManager.Apply(ApplicationTheme.Light, BackdropType.None, updateAccent: false);
+
+                Assert.Equal(3, app.Resources.MergedDictionaries.Count);
+
+                Color acrylic = Assert.IsType<Color>(app.TryFindResource("AcrylicBackgroundFillColorDefault"));
+                Assert.NotEqual(byte.MaxValue, acrylic.A);
+            });
+        }
+
+        [Fact]
         public Task ThemeSlotIsReusedAsync()
         {
             return WpfTestSta.RunOnStaAsync(static () =>

--- a/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
+++ b/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
@@ -401,9 +401,27 @@ namespace Fluence.Wpf.Tests
 
             return "brush=" + background.Color.ToString(CultureInfo.InvariantCulture)
                 + " token=" + tokenText
-                + " requestedTheme=" + Enum.GetName(typeof(ApplicationTheme), ApplicationThemeManager.CurrentTheme)
+                + " requestedTheme=" + ThemeName(ApplicationThemeManager.CurrentTheme)
                 + " highContrastSetting=" + SystemParameters.HighContrast.ToString(CultureInfo.InvariantCulture)
                 + " mergedDictionaries=[" + string.Join(", ", sources) + "]";
+        }
+
+        /// <summary>
+        /// Names a theme without <c>Enum.GetName</c>, whose generic overload the analyzers demand on
+        /// net10 and which does not exist on net472.
+        /// </summary>
+        /// <param name="theme">The theme to name.</param>
+        /// <returns>The theme name.</returns>
+        private static string ThemeName(ApplicationTheme theme)
+        {
+            return theme switch
+            {
+                ApplicationTheme.Light => "Light",
+                ApplicationTheme.Dark => "Dark",
+                ApplicationTheme.HighContrast => "HighContrast",
+                ApplicationTheme.Auto => "Auto",
+                _ => "Unknown",
+            };
         }
 
         private static void ResetApplication(Application application)

--- a/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
+++ b/Fluence.Wpf.Tests/TextRenderingPolicyTests.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -190,7 +191,10 @@ namespace Fluence.Wpf.Tests
                     System.Windows.Controls.Border surface = FindTemplatedSurface(comboBox, "PART_DropdownBorder");
 
                     Assert.Equal(ClearTypeHint.Auto, RenderOptions.GetClearTypeHint(surface));
-                    Assert.NotEqual(byte.MaxValue, Assert.IsType<SolidColorBrush>(surface.Background).Color.A);
+                    SolidColorBrush background = Assert.IsType<SolidColorBrush>(surface.Background);
+                    Assert.True(
+                        background.Color.A is not byte.MaxValue,
+                        "The dropdown surface must stay translucent. " + DescribeThemeState(application, background));
                 }
                 finally
                 {
@@ -376,6 +380,30 @@ namespace Fluence.Wpf.Tests
                     control.GetType().Name + " did not resolve a default template.");
 
             return Assert.IsType<System.Windows.Controls.Border>(template.FindName(surfaceName, control));
+        }
+
+        /// <summary>
+        /// Describes the published theme state behind a brush assertion. A theme-token failure is
+        /// almost always "the wrong dictionary is installed" rather than "the token is wrong", and
+        /// on a CI runner there is no debugger to ask, so the answer has to travel in the message.
+        /// </summary>
+        /// <param name="application">The test application.</param>
+        /// <param name="background">The brush the assertion read.</param>
+        /// <returns>A single-line description of the resolved theme and the installed dictionaries.</returns>
+        private static string DescribeThemeState(Application application, SolidColorBrush background)
+        {
+            object? token = application.TryFindResource("AcrylicBackgroundFillColorDefault");
+            string tokenText = token is Color color
+                ? color.ToString(CultureInfo.InvariantCulture)
+                : "missing";
+            IEnumerable<string> sources = application.Resources.MergedDictionaries
+                .Select(static dictionary => dictionary.Source?.ToString() ?? "computed");
+
+            return "brush=" + background.Color.ToString(CultureInfo.InvariantCulture)
+                + " token=" + tokenText
+                + " requestedTheme=" + Enum.GetName(typeof(ApplicationTheme), ApplicationThemeManager.CurrentTheme)
+                + " highContrastSetting=" + SystemParameters.HighContrast.ToString(CultureInfo.InvariantCulture)
+                + " mergedDictionaries=[" + string.Join(", ", sources) + "]";
         }
 
         private static void ResetApplication(Application application)

--- a/Fluence.Wpf/Theming/FluenceThemeEngine.cs
+++ b/Fluence.Wpf/Theming/FluenceThemeEngine.cs
@@ -46,6 +46,14 @@ namespace Fluence.Wpf.Theming
     internal static class FluenceThemeEngine
     {
         private const string PackBase = "pack://application:,,,/Fluence.Wpf;component/";
+
+        /// <summary>
+        /// Key stamped into every dictionary published at slot [0], so a previously published one
+        /// can be recognised and removed when the slots are seeded again. Typography and Generic are
+        /// identified by their pack URI; a computed dictionary is built in code and has no
+        /// <see cref="ResourceDictionary.Source"/>, so it needs a marker of its own.
+        /// </summary>
+        internal const string ComputedDictionaryMarker = "FluenceComputedDictionary";
         private static AccentIntent _intent = AccentIntent.System;
         private static bool _initialized;
 
@@ -177,6 +185,7 @@ namespace Fluence.Wpf.Theming
             ResourceDictionary computed = BrushFactory.Build(colors);
             SpecialBrushes.Add(computed, colors, theme);
             computed["AcrylicNoiseBrush"] = AcrylicNoiseHelper.GetNoiseBrush(); // preserve existing token
+            computed[ComputedDictionaryMarker] = true;
             return computed;
         }
 
@@ -251,6 +260,17 @@ namespace Fluence.Wpf.Theming
         {
             for (int i = dicts.Count - 1; i >= 0; i--)
             {
+                // A computed dictionary is built in code and has no Source, so it cannot be
+                // recognised by URI the way Typography and Generic can. It carries a marker key
+                // instead. Leaving a previously published one behind is not cosmetic: WPF resolves
+                // merged dictionaries last-wins, so a stale computed dictionary sitting past the
+                // freshly inserted slot [0] shadows every token the new one publishes.
+                if (dicts[i].Contains(ComputedDictionaryMarker))
+                {
+                    dicts.RemoveAt(i);
+                    continue;
+                }
+
                 string s = dicts[i].Source?.OriginalString.ToLowerInvariant() ?? string.Empty;
                 if (s.Contains("fluence.wpf;component", StringComparison.Ordinal) && s.Contains("themes/", StringComparison.Ordinal))
                 {


### PR DESCRIPTION
`main` was red on the net472 lane: `TextRenderingPolicyTests.ComboBoxDropdownSurface_KeepsDefaultClearTypeHintAsync` read an opaque brush where the Light `AcrylicBackgroundFillColorDefault` token is `#F0F9F9F9`. It reproduced nowhere locally, so the first commit here made the assertion report the published theme state. CI answered:

    brush=#FFFFFFFF token=#FF000000 requestedTheme=Light highContrastSetting=False
    mergedDictionaries=[computed, Typography, Generic, computed, computed, computed, computed]

Not high contrast, theme correctly Light, but four extra computed dictionaries appended past slot [2]. `RemoveFluenceDictionaries` recognises Typography and Generic by pack URI; the computed dictionary is built in code and has no `Source`, so seeding the slots again inserted a fresh one at [0] and left the previous one behind. WPF resolves merged dictionaries last-wins, so a leaked High Contrast dictionary answered the lookup.

Every published computed dictionary now carries a marker key the removal pass recognises. `BuildStandalone` is untouched, so the design-time snapshot and its drift guard are unaffected. `DictionaryStabilityTests` pins the re-seed path and fails without the fix (four dictionaries, opaque acrylic token).

Full net472 Release suite locally: 1117 total, 0 failed.