### PR TITLE
Use a bit more Linq for CodeQL's benefit.

### DIFF
--- a/Fluence.Wpf.Tests/WindowPolicyTests.cs
+++ b/Fluence.Wpf.Tests/WindowPolicyTests.cs
@@ -27,6 +27,7 @@
  */
 
 using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Shell;
@@ -797,19 +798,9 @@ namespace Fluence.Wpf.Tests
         {
             // Regression guard: DWMWA_COLOR_NONE hides the one border that composites against the
             // desktop, which is what produced the Light-theme halo around an inactive window.
-            foreach (bool active in new[] { true, false })
+            foreach (FramePlan plan in new[] { true, false }.SelectMany(static active => new[] { true, false }.Select(accent => WindowPolicy.BuildFramePlan(WindowState.Normal, active, accent, Caps(borderColor: true), Color.FromRgb(0x00, 0x78, 0xD4)))))
             {
-                foreach (bool accent in new[] { true, false })
-                {
-                    FramePlan plan = WindowPolicy.BuildFramePlan(
-                        WindowState.Normal,
-                        active,
-                        accent,
-                        Caps(borderColor: true),
-                        Color.FromRgb(0x00, 0x78, 0xD4));
-
-                    Assert.NotEqual(PInvoke.DWMWA_COLOR_NONE, plan.DwmBorderColor);
-                }
+                Assert.NotEqual(PInvoke.DWMWA_COLOR_NONE, plan.DwmBorderColor);
             }
         }
 
@@ -831,19 +822,9 @@ namespace Fluence.Wpf.Tests
         {
             // Regression guard for the Light-theme halo: an inner border painted over the window's
             // own surface shows as a pale line inside the system border, whatever token it uses.
-            foreach (bool active in new[] { true, false })
+            foreach (FramePlan plan in new[] { true, false }.SelectMany(static active => new[] { true, false }.Select(accent => WindowPolicy.BuildFramePlan(WindowState.Normal, active, accent, Caps(borderColor: true), Color.FromRgb(0x00, 0x78, 0xD4)))))
             {
-                foreach (bool accent in new[] { true, false })
-                {
-                    FramePlan plan = WindowPolicy.BuildFramePlan(
-                        WindowState.Normal,
-                        active,
-                        accent,
-                        Caps(borderColor: true),
-                        Color.FromRgb(0x00, 0x78, 0xD4));
-
-                    Assert.Equal(new Thickness(0), plan.TemplateBorderThickness);
-                }
+                Assert.Equal(new Thickness(0), plan.TemplateBorderThickness);
             }
         }
 

--- a/Fluence.Wpf/Theming/PublishFingerprint.cs
+++ b/Fluence.Wpf/Theming/PublishFingerprint.cs
@@ -27,6 +27,7 @@
  */
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
 using Fluence.Wpf.Helpers;
@@ -146,25 +147,7 @@ namespace Fluence.Wpf.Theming
         /// <param name="right">The second color map.</param>
         internal static bool ColorMapsEqual(IReadOnlyDictionary<string, Color> left, IReadOnlyDictionary<string, Color> right)
         {
-            if (ReferenceEquals(left, right))
-            {
-                return true;
-            }
-
-            if (left.Count != right.Count)
-            {
-                return false;
-            }
-
-            foreach (KeyValuePair<string, Color> entry in left)
-            {
-                if (!right.TryGetValue(entry.Key, out Color candidate) || candidate != entry.Value)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return ReferenceEquals(left, right) || (left.Count == right.Count && !left.Any(entry => !right.TryGetValue(entry.Key, out Color candidate) || candidate != entry.Value));
         }
 
         /// <summary>


### PR DESCRIPTION
﻿## Summary

As described.

## Verification

- [ ] `dotnet build Fluence.Wpf.sln -c Release --no-restore -v minimal` (0 errors / 0 warnings, both TFMs)
- [ ] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net472 --no-build`
- [ ] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net10.0-windows10.0.26100.0 --no-build`
- [ ] `pwsh .claude/hooks/post-tool-util.ps1 -CheckAll` passes (UTF-8 BOM, LF, banned APIs, no hard-coded hex or em/en dashes).
- [ ] Visual pass completed in `Fluence.Wpf.Demo` for Light, Dark, High Contrast, accent swap, and relevant backdrop.

## Checklist

- [ ] Public API changes have XML docs and tests; the test count does not drop below the baseline.
- [ ] Template or visual changes use canonical WinUI-style theme keys and `DynamicResource` where theme-bound (no inline hex colors).
- [ ] Visual or behavioral choices are grounded in a Section 4 reference authority (in-tree precedent, WinUI 3 CommonStyles, or .NET 10 WPF Themes).
- [ ] `CHANGELOG.md` is updated under `Unreleased`.
- [ ] Public docs are updated when consumer behavior changes.
- [ ] No unrelated files or local tool state are included.
