### PR TITLE
Update all NuGet packages to their latest versions.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,10 +8,10 @@
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.177" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.Extensions.StaticAnalysis" Version="10.9.0" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.16.1" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
     <!-- Fluence.Wpf -->
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.321" />
-    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.161" />
+    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.162" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.11" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />

--- a/Fluence.Wpf.Demo.Mvvm/packages.lock.json
+++ b/Fluence.Wpf.Demo.Mvvm/packages.lock.json
@@ -32,9 +32,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",

--- a/Fluence.Wpf.Demo/packages.lock.json
+++ b/Fluence.Wpf.Demo/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Meziantou.Polyfill": {
         "type": "Direct",
-        "requested": "[1.0.161, )",
-        "resolved": "1.0.161",
-        "contentHash": "Njk/Wz9mvxAkAYmHqsTCpDmc3QKidYHdHquuRxhN2xe390kZsUgZtvu4wUdxZ01U86Q4g2AhydQsUm/Jy960UQ=="
+        "requested": "[1.0.162, )",
+        "resolved": "1.0.162",
+        "contentHash": "l+mWqBHywJmboNsvLIIlH7/xEgKfoUxdXaeXRIaXIh+9NippMJT4g7j54OjWUDSCGD4vsNTxqxNwzxs/yLlu5g=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
@@ -32,9 +32,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",
@@ -123,9 +123,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",

--- a/Fluence.Wpf.Tests/packages.lock.json
+++ b/Fluence.Wpf.Tests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Meziantou.Polyfill": {
         "type": "Direct",
-        "requested": "[1.0.161, )",
-        "resolved": "1.0.161",
-        "contentHash": "Njk/Wz9mvxAkAYmHqsTCpDmc3QKidYHdHquuRxhN2xe390kZsUgZtvu4wUdxZ01U86Q4g2AhydQsUm/Jy960UQ=="
+        "requested": "[1.0.162, )",
+        "resolved": "1.0.162",
+        "contentHash": "l+mWqBHywJmboNsvLIIlH7/xEgKfoUxdXaeXRIaXIh+9NippMJT4g7j54OjWUDSCGD4vsNTxqxNwzxs/yLlu5g=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
@@ -41,9 +41,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -287,7 +287,7 @@
       "fluence.wpf.demo": {
         "type": "Project",
         "dependencies": {
-          "Fluence.Wpf": "[0.8.13-preview, )"
+          "Fluence.Wpf": "[0.8.17-preview, )"
         }
       },
       "Microsoft.Bcl.Memory": {
@@ -354,9 +354,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -525,14 +525,14 @@
       "fluence.wpf.demo": {
         "type": "Project",
         "dependencies": {
-          "Fluence.Wpf": "[0.8.13-preview, )"
+          "Fluence.Wpf": "[0.8.17-preview, )"
         }
       },
       "fluence.wpf.demo.mvvm": {
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Fluence.Wpf": "[0.8.13-preview, )"
+          "Fluence.Wpf": "[0.8.17-preview, )"
         }
       },
       "CommunityToolkit.Mvvm": {

--- a/Fluence.Wpf/packages.lock.json
+++ b/Fluence.Wpf/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Meziantou.Polyfill": {
         "type": "Direct",
-        "requested": "[1.0.161, )",
-        "resolved": "1.0.161",
-        "contentHash": "Njk/Wz9mvxAkAYmHqsTCpDmc3QKidYHdHquuRxhN2xe390kZsUgZtvu4wUdxZ01U86Q4g2AhydQsUm/Jy960UQ=="
+        "requested": "[1.0.162, )",
+        "resolved": "1.0.162",
+        "contentHash": "l+mWqBHywJmboNsvLIIlH7/xEgKfoUxdXaeXRIaXIh+9NippMJT4g7j54OjWUDSCGD4vsNTxqxNwzxs/yLlu5g=="
       },
       "Microsoft.Bcl.Memory": {
         "type": "Direct",
@@ -54,9 +54,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "System.Memory": {
         "type": "Direct",
@@ -155,9 +155,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",
@@ -197,9 +197,9 @@
       },
       "Meziantou.Polyfill": {
         "type": "Direct",
-        "requested": "[1.0.161, )",
-        "resolved": "1.0.161",
-        "contentHash": "Njk/Wz9mvxAkAYmHqsTCpDmc3QKidYHdHquuRxhN2xe390kZsUgZtvu4wUdxZ01U86Q4g2AhydQsUm/Jy960UQ=="
+        "requested": "[1.0.162, )",
+        "resolved": "1.0.162",
+        "contentHash": "l+mWqBHywJmboNsvLIIlH7/xEgKfoUxdXaeXRIaXIh+9NippMJT4g7j54OjWUDSCGD4vsNTxqxNwzxs/yLlu5g=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
@@ -230,9 +230,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.16.1, )",
-        "resolved": "4.16.1",
-        "contentHash": "AGzq3UZvIwTGSh9xyIna+Q9F666S8UaLlX/Pk3Iz21qIAWjL8iYporVCcX1k/oi5chrRZ8VJRahup4me4HZptw=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",


### PR DESCRIPTION
﻿## Summary

As described.

## Verification

- [ ] `dotnet build Fluence.Wpf.sln -c Release --no-restore -v minimal` (0 errors / 0 warnings, both TFMs)
- [ ] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net472 --no-build`
- [ ] `dotnet test Fluence.Wpf.Tests/Fluence.Wpf.Tests.csproj -c Release -f net10.0-windows10.0.26100.0 --no-build`
- [ ] `pwsh .claude/hooks/post-tool-util.ps1 -CheckAll` passes (UTF-8 BOM, LF, banned APIs, no hard-coded hex or em/en dashes).
- [ ] Visual pass completed in `Fluence.Wpf.Demo` for Light, Dark, High Contrast, accent swap, and relevant backdrop.

## Checklist

- [ ] Public API changes have XML docs and tests; the test count does not drop below the baseline.
- [ ] Template or visual changes use canonical WinUI-style theme keys and `DynamicResource` where theme-bound (no inline hex colors).
- [ ] Visual or behavioral choices are grounded in a Section 4 reference authority (in-tree precedent, WinUI 3 CommonStyles, or .NET 10 WPF Themes).
- [ ] `CHANGELOG.md` is updated under `Unreleased`.
- [ ] Public docs are updated when consumer behavior changes.
- [ ] No unrelated files or local tool state are included.
